### PR TITLE
Add parse_input tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tests/test_parse_input.py
+++ b/tests/test_parse_input.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from tien_len_full import Game, Card
+
+
+def setup_hand():
+    return [
+        Card('Spades', '3'),
+        Card('Hearts', '4'),
+        Card('Diamonds', '5'),
+    ]
+
+
+def test_parse_by_index():
+    game = Game()
+    hand = setup_hand()
+    cmd, cards = game.parse_input('1 2', hand)
+    assert cmd == 'play'
+    assert cards == [hand[0], hand[1]]
+
+
+def test_parse_by_notation():
+    game = Game()
+    hand = setup_hand()
+    cmd, cards = game.parse_input('3\u2660 4\u2665', hand)
+    assert cmd == 'play'
+    assert cards == [hand[0], hand[1]]
+
+
+def test_negative_index():
+    game = Game()
+    hand = setup_hand()
+    cmd, msg = game.parse_input('-1', hand)
+    assert (cmd, msg) == ('error', 'Invalid index')
+
+
+def test_index_out_of_range():
+    game = Game()
+    hand = setup_hand()
+    cmd, msg = game.parse_input('10', hand)
+    assert (cmd, msg) == ('error', 'Invalid index')

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -138,6 +138,8 @@ class Game:
             else:
                 try:
                     idx = int(p) - 1
+                    if idx < 0 or idx >= len(hand):
+                        return 'error', 'Invalid index'
                     cards.append(hand[idx])
                 except:
                     return 'error', 'Invalid index'


### PR DESCRIPTION
## Summary
- test parse_input with valid numeric and suit notation inputs
- ensure invalid indices return an error
- ignore `__pycache__` and compiled Python files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a90a14a48326bfb4c18f820388a1