### PR TITLE
Add CI workflow for linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+      - name: Lint
+        run: flake8 tien_len_full.py
+      - name: Test
+        run: pytest


### PR DESCRIPTION
## Summary
- run flake8 and pytest on each push and PR
- install dependencies using actions/setup-python

## Testing
- `flake8 tien_len_full.py` *(fails: E501 line too long)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845abc890b88326bf37e57f29acfb46