### PR TITLE
Update pass rule docstring

### DIFF
--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -1,7 +1,9 @@
 # tien_len_full.py
 """
 Tiến Lên full game with refactored AI, modular play loop, and full CLI utilities.
-Fixed first-turn pass rule: player cannot pass on first turn if holding 3♠.
+
+Only the human player is forbidden from passing on their initial turn when they
+hold the 3♠, matching the current implementation.
 """
 import random
 import datetime


### PR DESCRIPTION
## Summary
- clarify that only human players can't pass on the first turn when they hold 3♠

## Testing
- `python -m py_compile tien_len_full.py`


------
https://chatgpt.com/codex/tasks/task_e_6845a8f07648832688fc032b60f89d03