### PR TITLE
Fix index validation in parse_input

### DIFF
--- a/test_parse_input.py
+++ b/test_parse_input.py
@@ -1,0 +1,26 @@
+import pytest
+from tien_len_full import Game, Card
+
+
+def test_parse_input_valid_index():
+    g = Game()
+    hand = [Card('Spades', '3'), Card('Hearts', '4')]
+    cmd, cards = g.parse_input('1', hand)
+    assert cmd == 'play'
+    assert cards == [hand[0]]
+
+
+def test_parse_input_invalid_high_index():
+    g = Game()
+    hand = [Card('Spades', '3'), Card('Hearts', '4')]
+    cmd, msg = g.parse_input('3', hand)
+    assert cmd == 'error'
+    assert msg == 'Invalid index'
+
+
+def test_parse_input_invalid_negative_index():
+    g = Game()
+    hand = [Card('Spades', '3'), Card('Hearts', '4')]
+    cmd, msg = g.parse_input('0', hand)
+    assert cmd == 'error'
+    assert msg == 'Invalid index'

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -138,9 +138,11 @@ class Game:
             else:
                 try:
                     idx = int(p) - 1
-                    cards.append(hand[idx])
-                except:
+                except ValueError:
                     return 'error', 'Invalid index'
+                if not 0 <= idx < len(hand):
+                    return 'error', 'Invalid index'
+                cards.append(hand[idx])
         return 'play', cards
 
     def hint(self, current):


### PR DESCRIPTION
## Summary
- prevent negative or out-of-range indexing when selecting cards
- add tests for parse_input index handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a8c19dac8326b16434fa76752a51