### PR TITLE
Fix input parsing for duplicate card selections

### DIFF
--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -136,15 +136,18 @@ class Game:
                 found = [c for c in hand if c.rank == rank and c.suit == suit]
                 if not found:
                     return 'error', f"Card {p} not in hand"
-                cards.append(found[0])
+                card = found[0]
             else:
                 try:
                     idx = int(p) - 1
                     if idx < 0 or idx >= len(hand):
                         return 'error', 'Invalid index'
-                    cards.append(hand[idx])
-                except:
+                    card = hand[idx]
+                except ValueError:
                     return 'error', 'Invalid index'
+            if card in cards:
+                return 'error', 'Duplicate card'
+            cards.append(card)
         return 'play', cards
 
     def hint(self, current):


### PR DESCRIPTION
## Summary
- improve `parse_input` to reject duplicate card selections and use specific ValueError handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684839d87a6083269425bfe987144be7