### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+      - name: Lint
+        run: flake8 tien_len_full.py
+      - name: Test
+        run: pytest


### PR DESCRIPTION
## Summary
- add CI workflow using GitHub Actions
- install flake8 and pytest
- run linting and tests on push and pull request events

## Testing
- `flake8 tien_len_full.py` *(fails: E501 line too long, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684883ec81288326bd842032fb87e315