### PR TITLE
Add pygame GUI skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Select cards by clicking them and then press **Play Selected**. Press
 **Pass** to skip your turn (subject to the first‑turn rule). AI turns
 are handled automatically.
 
+## Pygame prototype
+
+An experimental interface built with **pygame** is available in
+`pygame_gui.py`. It currently draws your hand as rectangles on a green
+table background. Launch it with:
+
+```bash
+python3 pygame_gui.py
+```
+
 ## Running tests
 
 Install requirements first:

--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -1,0 +1,52 @@
+import sys
+import pygame
+from tien_len_full import Game
+
+# Basic constants for card layout
+CARD_WIDTH = 60
+CARD_HEIGHT = 90
+CARD_GAP = 10
+SCREEN_SIZE = (800, 600)
+FELT_GREEN = (0, 128, 0)
+
+
+def draw_hand(screen, font, hand):
+    """Draw the first five cards of ``hand`` at the bottom of ``screen``."""
+    for i, card in enumerate(hand[:5]):
+        x = 50 + i * (CARD_WIDTH + CARD_GAP)
+        y = SCREEN_SIZE[1] - CARD_HEIGHT - 40
+        rect = pygame.Rect(x, y, CARD_WIDTH, CARD_HEIGHT)
+        pygame.draw.rect(screen, (255, 255, 255), rect)
+        text = font.render(str(card), True, (0, 0, 0))
+        screen.blit(text, (rect.x + 5, rect.y + 5))
+
+
+def main():
+    pygame.init()
+    screen = pygame.display.set_mode(SCREEN_SIZE)
+    pygame.display.set_caption("Tiến Lên - Pygame Prototype")
+    clock = pygame.time.Clock()
+
+    font = pygame.font.SysFont(None, 24)
+
+    game = Game()
+    game.setup()
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+
+        screen.fill(FELT_GREEN)
+        draw_hand(screen, font, game.players[0].hand)
+
+        pygame.display.flip()
+        clock.tick(60)
+
+    pygame.quit()
+    sys.exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 coverage
+pygame


### PR DESCRIPTION
## Summary
- add an experimental `pygame_gui.py` showing a simple hand
- document the Pygame prototype in the README
- include `pygame` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c57ed817883268fc34497afdd0a67