### PR TITLE
Fix badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tiến Lên
-[![CI](https://github.com/YOUR_GITHUB_USERNAME/Tien-Len/actions/workflows/ci.yml/badge.svg)](https://github.com/YOUR_GITHUB_USERNAME/Tien-Len/actions/workflows/ci.yml)
-[![Coverage](https://codecov.io/gh/YOUR_GITHUB_USERNAME/Tien-Len/branch/main/graph/badge.svg)](https://codecov.io/gh/YOUR_GITHUB_USERNAME/Tien-Len)
+[![CI](https://github.com/Flexiblefabric/Tien-Len/actions/workflows/ci.yml/badge.svg)](https://github.com/Flexiblefabric/Tien-Len/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/Flexiblefabric/Tien-Len/branch/main/graph/badge.svg)](https://codecov.io/gh/Flexiblefabric/Tien-Len)
 
 This repository contains a simple command line implementation of the
 Vietnamese card game **Tiến Lên** and a small Tkinter-based GUI.


### PR DESCRIPTION
## Summary
- update README badges to point to the Flexiblefabric repo

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eed8c54988326bcc1c16a4bb9e3b1