### PR TITLE
Add drag-and-drop interface and responsive GUI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 coverage
+pillow


### PR DESCRIPTION
## Summary
- improve GUI with new Play button handling `is_valid`/`process_play`
- highlight selected cards
- support drag-and-drop card play and basic animation
- resize card images based on window width
- popup restart option when game ends
- add Pillow dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef37330208326aa953f2ea91a3123