### PR TITLE
Add sound module with tests

### DIFF
--- a/sound.py
+++ b/sound.py
@@ -1,0 +1,46 @@
+"""Simple sound effect utilities using pygame's mixer."""
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import pygame
+    pygame.mixer.init()
+    _ENABLED = True
+except Exception:  # pragma: no cover - if mixer init fails
+    pygame = None
+    _ENABLED = False
+
+_SOUNDS: dict[str, "pygame.mixer.Sound"] = {}
+
+
+def load(name: str, path: str | Path) -> bool:
+    """Load a sound effect from ``path`` under ``name``.
+
+    Returns ``True`` on success.  Loading does nothing if the mixer is
+    disabled or the file does not exist.
+    """
+    if not _ENABLED:
+        return False
+    p = Path(path)
+    if not p.is_file():
+        return False
+    try:
+        snd = pygame.mixer.Sound(str(p))
+    except Exception:
+        return False
+    _SOUNDS[name] = snd
+    return True
+
+
+def play(name: str) -> None:
+    """Play a loaded sound effect identified by ``name``."""
+    if not _ENABLED:
+        return
+    snd = _SOUNDS.get(name)
+    if snd is None:
+        return
+    try:
+        snd.play()
+    except Exception:
+        pass

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -1,0 +1,70 @@
+import types
+from unittest.mock import MagicMock, patch
+
+import sound
+
+
+def _stub_pygame(mock_sound):
+    mixer = types.SimpleNamespace(Sound=mock_sound)
+    return types.SimpleNamespace(mixer=mixer)
+
+
+def test_load_success(tmp_path):
+    wav = tmp_path / "a.wav"
+    wav.write_text("data")
+    mock_instance = MagicMock()
+    with patch.object(sound, "pygame", _stub_pygame(MagicMock(return_value=mock_instance))):
+        with patch("sound.Path.is_file", return_value=True):
+            sound._ENABLED = True
+            sound._SOUNDS.clear()
+            assert sound.load("hit", wav)
+            assert sound._SOUNDS["hit"] is mock_instance
+
+
+def test_load_disabled_or_missing(tmp_path):
+    wav = tmp_path / "a.wav"
+    wav.write_text("data")
+    mock_cls = MagicMock()
+    # Disabled
+    with patch.object(sound, "pygame", _stub_pygame(mock_cls)):
+        with patch("sound.Path.is_file", return_value=True):
+            sound._ENABLED = False
+            sound._SOUNDS.clear()
+            assert not sound.load("foo", wav)
+            mock_cls.assert_not_called()
+            assert "foo" not in sound._SOUNDS
+    # Missing file
+    with patch.object(sound, "pygame", _stub_pygame(mock_cls)):
+        with patch("sound.Path.is_file", return_value=False):
+            sound._ENABLED = True
+            sound._SOUNDS.clear()
+            assert not sound.load("bar", wav)
+            mock_cls.assert_not_called()
+            assert "bar" not in sound._SOUNDS
+
+
+def test_play_noop_when_disabled_or_unknown():
+    mock_sound = MagicMock()
+    sound._SOUNDS.clear()
+    sound._SOUNDS["shoot"] = mock_sound
+
+    # Disabled
+    sound._ENABLED = False
+    sound.play("shoot")
+    mock_sound.play.assert_not_called()
+
+    # Unknown name
+    sound._ENABLED = True
+    mock_sound.play.reset_mock()
+    sound.play("missing")
+    mock_sound.play.assert_not_called()
+
+
+def test_play_handles_errors():
+    mock_sound = MagicMock()
+    mock_sound.play.side_effect = Exception("boom")
+    sound._SOUNDS.clear()
+    sound._SOUNDS["explode"] = mock_sound
+    sound._ENABLED = True
+    sound.play("explode")  # should not raise
+    mock_sound.play.assert_called_once()


### PR DESCRIPTION
## Summary
- implement simple `sound` helper
- test loading and playing behavior with pygame mocked

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eff715cec8326be88fa56a5354dc5