### PR TITLE
Add warning when sound file missing

### DIFF
--- a/sound.py
+++ b/sound.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import warnings
 
 try:
     import pygame
@@ -24,6 +25,7 @@ def load(name: str, path: str | Path) -> bool:
         return False
     p = Path(path)
     if not p.is_file():
+        warnings.warn(f"Sound file '{p}' not found", RuntimeWarning)
         return False
     try:
         snd = pygame.mixer.Sound(str(p))


### PR DESCRIPTION
## Summary
- warn when `sound.load` cannot find the audio file

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f022ee84483269d1e56372dc2bc33