### PR TITLE
Allow AI to play long sequences

### DIFF
--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -76,3 +76,35 @@ def test_reset_pile_after_consecutive_passes():
     assert game.current_combo is None
     assert game.pass_count == 0
     assert game.pile == []
+
+
+def test_ai_plays_long_sequence():
+    game = Game()
+    ai = game.players[1]
+    ai.hand = [
+        Card('Spades', '7'),
+        Card('Spades', '8'),
+        Card('Spades', '9'),
+        Card('Spades', '10'),
+        Card('Spades', 'J'),
+    ]
+    game.current_idx = 1
+    move = game.ai_play(None)
+    assert set(move) == set(ai.hand)
+
+
+def test_generate_moves_calls_is_valid_for_long_sequence():
+    game = Game()
+    ai = game.players[1]
+    ai.hand = [
+        Card('Hearts', '4'),
+        Card('Hearts', '5'),
+        Card('Hearts', '6'),
+        Card('Hearts', '7'),
+        Card('Hearts', '8'),
+    ]
+    game.current_idx = 1
+    with patch.object(Game, 'is_valid', wraps=game.is_valid) as mock_valid:
+        moves = game.generate_valid_moves(ai, None)
+        assert any(len(m) == 5 for m in moves)
+        assert any(len(args[1]) == 5 for args, _ in mock_valid.call_args_list)

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -327,7 +327,7 @@ class Game:
         """Return every playable move for ``player`` given ``current``."""
 
         moves = []
-        for n in range(1, 5):
+        for n in range(1, len(player.hand) + 1):
             for combo_cards in combinations(player.hand, n):
                 lst = list(combo_cards)
                 ok, _ = self.is_valid(player, lst, current)


### PR DESCRIPTION
## Summary
- search long sequences when generating AI moves
- add regression tests for AI sequence generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f09689a908326be330935b73130fd