### PR TITLE
Add menu and settings dialog

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -17,6 +17,22 @@ class GameGUI:
     def __init__(self, root: tk.Tk):
         self.root = root
         self.root.title("Tiến Lên GUI Prototype")
+        # Setup menu bar
+        menubar = tk.Menu(self.root)
+        self.root.config(menu=menubar)
+        file_menu = tk.Menu(menubar, tearoff=0)
+        file_menu.add_command(label="New Game", command=self.restart_game)
+        file_menu.add_command(label="Quit", command=self.root.destroy)
+        menubar.add_cascade(label="File", menu=file_menu)
+
+        opt_menu = tk.Menu(menubar, tearoff=0)
+        opt_menu.add_command(label="Settings...", command=self.open_settings)
+        menubar.add_cascade(label="Options", menu=opt_menu)
+
+        help_menu = tk.Menu(menubar, tearoff=0)
+        help_menu.add_command(label="About/Rules...", command=self.show_about)
+        menubar.add_cascade(label="Help", menu=help_menu)
+
         self.fullscreen = False
         # Base font for text fallback buttons when images are missing
         self.card_font = tkfont.Font(size=12)
@@ -58,6 +74,7 @@ class GameGUI:
         self.score_var = tk.StringVar()
         self.scores = {p.name: 0 for p in self.game.players}
         self.overlay_active = False
+        self.table_cloth_color = "darkgreen"
 
         self.main_area = tk.Frame(root)
         self.main_area.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
@@ -67,6 +84,7 @@ class GameGUI:
         self.table_view = TableView(
             self.main_area, self.game, self.base_images, self.scaled_images, self.CARD_WIDTH
         )
+        self.table_view.config(bg=self.table_cloth_color)
         self.table_view.pack(pady=5)
         tk.Label(self.main_area, textvariable=self.info_var).pack(pady=5)
         self.turn_label = tk.Label(self.main_area, textvariable=self.turn_var, font=("Arial", 12, "bold"))
@@ -281,6 +299,18 @@ class GameGUI:
         else:
             pygame.mixer.music.unpause()
             self.music_btn.config(text="Pause Music")
+
+    def open_settings(self):
+        from settings_dialog import SettingsDialog
+        SettingsDialog(self.root, self)
+
+    def show_about(self):
+        msg = (
+            "This GUI demonstrates the Vietnamese card game Tiến Lên.\n"
+            "Select cards and press Play to beat the pile.\n"
+            "Sequences cannot contain the 2 by default."
+        )
+        messagebox.showinfo("About", msg)
 
     def toggle_card(self, card):
         if card in self.selected:

--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -1,0 +1,81 @@
+import tkinter as tk
+from tkinter import colorchooser
+from tkinter import ttk
+import sound
+import pygame
+import tien_len_full as rules
+
+class SettingsDialog(tk.Toplevel):
+    """Modal dialog for adjusting game options."""
+
+    def __init__(self, master: tk.Tk, gui) -> None:
+        super().__init__(master)
+        self.gui = gui
+        self.title("Settings")
+        self.resizable(False, False)
+        self.transient(master)
+        self.grab_set()
+
+        frame = tk.Frame(self)
+        frame.pack(padx=10, pady=10)
+
+        # Sound and music toggles
+        self.sound_var = tk.BooleanVar(value=sound._ENABLED)
+        tk.Checkbutton(frame, text="Enable sound effects", variable=self.sound_var).pack(anchor="w")
+        self.music_var = tk.BooleanVar(value=pygame.mixer.music.get_busy() if pygame else False)
+        tk.Checkbutton(frame, text="Enable music", variable=self.music_var).pack(anchor="w")
+
+        tk.Label(frame, text="Volume").pack(anchor="w")
+        self.vol_var = tk.DoubleVar(value=self.gui.sfx_volume.get())
+        tk.Scale(frame, from_=0, to=1, orient=tk.HORIZONTAL, resolution=0.1, variable=self.vol_var).pack(anchor="w")
+
+        # Card back selector (placeholder options)
+        backs = [k for k in self.gui.card_images if k.startswith("card_back")]
+        if not backs:
+            backs = ["card_back"]
+        self.back_var = tk.StringVar(value=backs[0])
+        tk.Label(frame, text="Card back").pack(anchor="w")
+        ttk.OptionMenu(frame, self.back_var, backs[0], *backs).pack(anchor="w")
+
+        # Table cloth colour
+        tk.Label(frame, text="Table colour").pack(anchor="w")
+        self.colour = self.gui.table_cloth_color
+        self.colour_lbl = tk.Label(frame, width=10, bg=self.colour)
+        self.colour_lbl.pack(anchor="w")
+        tk.Button(frame, text="Choose...", command=self.choose_colour).pack(anchor="w")
+
+        # Rule variant
+        self.no2_var = tk.BooleanVar(value=not rules.ALLOW_2_IN_SEQUENCE)
+        tk.Checkbutton(frame, text="Disallow 2 in sequences", variable=self.no2_var).pack(anchor="w")
+
+        tk.Button(frame, text="OK", command=self.on_ok).pack(pady=(5,0))
+
+    def choose_colour(self) -> None:
+        col = colorchooser.askcolor(self.colour, parent=self)[1]
+        if col:
+            self.colour = col
+            self.colour_lbl.config(bg=col)
+
+    def on_ok(self) -> None:
+        sound._ENABLED = self.sound_var.get()
+        rules.ALLOW_2_IN_SEQUENCE = not self.no2_var.get()
+        val = float(self.vol_var.get())
+        self.gui.sfx_volume.set(val)
+        sound.set_volume(val)
+        if pygame:
+            pygame.mixer.music.set_volume(val)
+            if self.music_var.get():
+                pygame.mixer.music.unpause()
+            else:
+                pygame.mixer.music.pause()
+        self.gui.table_cloth_color = self.colour
+        self.gui.table_view.config(bg=self.colour)
+        back = self.back_var.get()
+        img = self.gui.card_images.get(back)
+        if img:
+            self.gui.card_back = img
+            try:
+                self.gui.root.iconphoto(False, img)
+            except Exception:
+                pass
+        self.destroy()

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -43,6 +43,12 @@ SUIT_SYMBOLS = {'♠': 'Spades', '♥': 'Hearts', '♦': 'Diamonds', '♣': 'Clu
 SUITS = list(SUIT_SYMBOLS.values())
 RANKS = ['3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A', '2']
 
+# Global rule toggles
+# ``ALLOW_2_IN_SEQUENCE`` controls whether suited sequences may contain a 2.
+# The default preserves the house rule used by the tests which forbids 2s
+# in sequences.
+ALLOW_2_IN_SEQUENCE = False
+
 # Rough ranking used by the very simple AI to choose which move to play.  Higher
 # values are better.
 TYPE_PRIORITY = {'bomb': 5, 'sequence': 4, 'triple': 3, 'pair': 2, 'single': 1}
@@ -112,8 +118,8 @@ def is_sequence(cards) -> bool:
 
     if len(cards) < 3:
         return False
-    # Sequences cannot contain a 2 under the house rules used here
-    if any(c.rank == '2' for c in cards):
+    # Optionally disallow sequences containing a 2
+    if not ALLOW_2_IN_SEQUENCE and any(c.rank == '2' for c in cards):
         return False
     # All cards must share the same suit
     if len({c.suit for c in cards}) != 1:


### PR DESCRIPTION
## Summary
- add GUI menu with File, Options, Help entries
- implement SettingsDialog for sound and appearance preferences
- allow optional sequences with 2s via `ALLOW_2_IN_SEQUENCE`
- integrate menu actions in GameGUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2d4855b88326a8990a37b66377bb