### PR TITLE
Add AI difficulty slider

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -39,6 +39,9 @@ class GameGUI:
         self.card_font = tkfont.Font(size=12)
         self.game = Game()
         self.game.setup()
+        # Difficulty multiplier affecting AI aggressiveness
+        self.ai_difficulty = 1.0
+        self.game.ai_difficulty = self.ai_difficulty
 
         # Load sound effects and background music
         sdir = Path(__file__).with_name("assets") / "sound"

--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -48,6 +48,11 @@ class SettingsDialog(tk.Toplevel):
         self.no2_var = tk.BooleanVar(value=not rules.ALLOW_2_IN_SEQUENCE)
         tk.Checkbutton(frame, text="Disallow 2 in sequences", variable=self.no2_var).pack(anchor="w")
 
+        # AI difficulty slider
+        tk.Label(frame, text="AI difficulty").pack(anchor="w")
+        self.diff_var = tk.DoubleVar(value=self.gui.ai_difficulty)
+        tk.Scale(frame, from_=0.5, to=3.0, resolution=0.1, orient=tk.HORIZONTAL, variable=self.diff_var).pack(anchor="w")
+
         tk.Button(frame, text="OK", command=self.on_ok).pack(pady=(5,0))
 
     def choose_colour(self) -> None:
@@ -78,4 +83,7 @@ class SettingsDialog(tk.Toplevel):
                 self.gui.root.iconphoto(False, img)
             except Exception:
                 pass
+        diff = float(self.diff_var.get())
+        self.gui.ai_difficulty = diff
+        self.gui.game.ai_difficulty = diff
         self.destroy()

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -176,6 +176,8 @@ class Game:
         self.current_combo: list[Card] | None = None
         self.history: list[tuple[int, str]] = []
         self.current_round = 1
+        # Multiplier influencing how aggressively the AI plays
+        self.ai_difficulty = 1.0
 
     def setup(self):
         """Shuffle, deal and determine the starting player."""
@@ -351,7 +353,8 @@ class Game:
         rank_val = max(RANKS.index(c.rank) for c in move)
         remaining = [c for c in player.hand if c not in move]
         finish = 1 if not remaining else 0
-        return (base, finish, rank_val)
+        diff = getattr(self, "ai_difficulty", 1.0)
+        return (base, finish * diff, rank_val * diff)
 
     def ai_play(self, current):
         """Choose a move for the current AI player."""


### PR DESCRIPTION
## Summary
- expose AI difficulty multiplier on `GameGUI`
- let Settings dialog change the AI difficulty via a slider
- scale ranking and finishing weights in `Game.score_move` based on difficulty

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3151ffd8832697df075447324624