### PR TITLE
Add accessibility features

### DIFF
--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -51,7 +51,13 @@ class SettingsDialog(tk.Toplevel):
         # AI difficulty slider
         tk.Label(frame, text="AI difficulty").pack(anchor="w")
         self.diff_var = tk.DoubleVar(value=self.gui.ai_difficulty)
-        tk.Scale(frame, from_=0.5, to=3.0, resolution=0.1, orient=tk.HORIZONTAL, variable=self.diff_var).pack(anchor="w")
+        tk.Scale(frame, from_=0.5, to=3.0, resolution=0.1, orient=tk.HORIZONTAL,
+                 variable=self.diff_var).pack(anchor="w")
+
+        # Accessibility
+        self.hc_var = tk.BooleanVar(value=self.gui.high_contrast)
+        tk.Checkbutton(frame, text="High contrast mode",
+                       variable=self.hc_var).pack(anchor="w", pady=(5, 0))
 
         tk.Button(frame, text="OK", command=self.on_ok).pack(pady=(5,0))
 
@@ -86,4 +92,5 @@ class SettingsDialog(tk.Toplevel):
         diff = float(self.diff_var.get())
         self.gui.ai_difficulty = diff
         self.gui.game.ai_difficulty = diff
+        self.gui.set_high_contrast(self.hc_var.get())
         self.destroy()

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock, patch
+import sys
+
+sys.modules.setdefault('pygame', MagicMock())
+
+import gui
+
+
+def make_gui_stub(root):
+    g = gui.GameGUI.__new__(gui.GameGUI)
+    g.root = root
+    g.card_font = MagicMock()
+    g.update_display = MagicMock()
+    return g
+
+
+def test_set_high_contrast_toggle():
+    root = MagicMock()
+    gui_obj = make_gui_stub(root)
+    default_font = MagicMock()
+    with patch('gui.tkfont.nametofont', return_value=default_font):
+        gui_obj.set_high_contrast(True)
+        assert gui_obj.high_contrast is True
+        default_font.configure.assert_called_with(size=12)
+        gui_obj.card_font.configure.assert_called_with(size=16)
+        root.tk_setPalette.assert_called()
+        gui_obj.update_display.assert_called_once()
+
+        root.reset_mock()
+        default_font.configure.reset_mock()
+        gui_obj.card_font.configure.reset_mock()
+        gui_obj.update_display.reset_mock()
+
+        gui_obj.set_high_contrast(False)
+        assert gui_obj.high_contrast is False
+        default_font.configure.assert_called_with(size=10)
+        gui_obj.card_font.configure.assert_called_with(size=12)
+        root.tk_setPalette.assert_called()
+        gui_obj.update_display.assert_called_once()
+
+
+def test_show_rules_creates_modal():
+    root = MagicMock()
+    gui_obj = make_gui_stub(root)
+    win = MagicMock()
+    with patch('gui.tk.Toplevel', return_value=win) as mock_top, \
+         patch('gui.tk.Label') as mock_label, \
+         patch('gui.tk.Button') as mock_button:
+        gui_obj.show_rules()
+        mock_top.assert_called_with(gui_obj.root)
+        win.title.assert_called_with('Game Rules')
+        win.transient.assert_called_with(gui_obj.root)
+        win.grab_set.assert_called_once()
+        mock_label.assert_called()
+        mock_button.assert_called()
+
+
+def test_show_menu_overlay():
+    root = MagicMock()
+    gui_obj = make_gui_stub(root)
+    overlay = MagicMock()
+    box = MagicMock()
+    with patch('gui.tk.Frame', side_effect=[overlay, box]) as mock_frame, \
+         patch('gui.tk.Label') as mock_label, \
+         patch('gui.tk.Button') as mock_button:
+        gui_obj.show_menu()
+        mock_frame.assert_any_call(gui_obj.root, bg='#00000080')
+        overlay.place.assert_called_with(relx=0, rely=0, relwidth=1, relheight=1)
+        assert mock_button.call_count >= 4
+


### PR DESCRIPTION
## Summary
- add "High contrast" setting
- implement rules overlay window
- add tests for GUI accessibility functions
- display menu splash screen with basic actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f43c197d08326ae8a7860df02c126