### PR TITLE
Remove redundant AI move logging

### DIFF
--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -592,8 +592,6 @@ class Game:
             cards = self.cli_input(self.current_combo)
         else:
             cards = self.ai_play(self.current_combo)
-            print(f"{p.name} plays {cards}")
-            log_action(f"{p.name} plays {cards}")
 
         ok, _ = self.is_valid(p, cards, self.current_combo)
         if not ok:


### PR DESCRIPTION
## Summary
- clean up handle_turn by removing duplicate print and log_action calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f52e7035083268cfadafe7540eab4