### PR TITLE
Handle missing pygame

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -10,7 +10,10 @@ from tien_len_full import Game, detect_combo, SUITS, RANKS
 from views import TableView, HandView
 from tooltip import ToolTip
 import sound
-import pygame
+try:
+    import pygame
+except ImportError:  # pragma: no cover - pygame optional
+    pygame = None
 
 
 class GameGUI:

--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -2,7 +2,10 @@ import tkinter as tk
 from tkinter import colorchooser
 from tkinter import ttk
 import sound
-import pygame
+try:
+    import pygame
+except ImportError:  # pragma: no cover - pygame optional
+    pygame = None
 import tien_len_full as rules
 
 class SettingsDialog(tk.Toplevel):


### PR DESCRIPTION
## Summary
- guard pygame imports in gui module
- guard pygame imports in settings dialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6e65d4d48326be95b1e1823bb984