### PR TITLE
Fix Tk palette reset call

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -264,8 +264,8 @@ class GameGUI:
                                    activeBackground="#333",
                                    activeForeground="white")
         else:
-            # Empty call resets to defaults
-            self.root.tk_setPalette("")
+            # Calling with no arguments resets Tk colors to defaults
+            self.root.tk_setPalette()
         self.update_display()
 
     def on_resize(self, event):


### PR DESCRIPTION
## Summary
- ensure set_high_contrast resets palette using `tk_setPalette()`
- explain that calling without args restores Tk defaults

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f75e746a4832693d3de8c33962912