### PR TITLE
Fix Tk color reset bug

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -23,6 +23,8 @@ class GameGUI:
     def __init__(self, root: tk.Tk):
         self.root = root
         self.root.title("Tiến Lên GUI Prototype")
+        # Capture the window's default background color so we can restore it
+        self._default_bg = self.root.cget("background")
         # Setup menu bar
         menubar = tk.Menu(self.root)
         self.root.config(menu=menubar)
@@ -264,8 +266,8 @@ class GameGUI:
                                    activeBackground="#333",
                                    activeForeground="white")
         else:
-            # Calling with no arguments resets Tk colors to defaults
-            self.root.tk_setPalette()
+            # Restore the palette to the window's original background color
+            self.root.tk_setPalette(background=self._default_bg)
         self.update_display()
 
     def on_resize(self, event):

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -9,6 +9,9 @@ import gui
 def make_gui_stub(root):
     g = gui.GameGUI.__new__(gui.GameGUI)
     g.root = root
+    # Provide cget so set_high_contrast can read the default background
+    g.root.cget = MagicMock(return_value="white")
+    g._default_bg = "white"
     g.card_font = MagicMock()
     g.update_display = MagicMock()
     return g
@@ -23,7 +26,8 @@ def test_set_high_contrast_toggle():
         assert gui_obj.high_contrast is True
         default_font.configure.assert_called_with(size=12)
         gui_obj.card_font.configure.assert_called_with(size=16)
-        root.tk_setPalette.assert_called()
+        root.tk_setPalette.assert_called_with(background="black", foreground="white",
+                                             activeBackground="#333", activeForeground="white")
         gui_obj.update_display.assert_called_once()
 
         root.reset_mock()
@@ -35,7 +39,7 @@ def test_set_high_contrast_toggle():
         assert gui_obj.high_contrast is False
         default_font.configure.assert_called_with(size=10)
         gui_obj.card_font.configure.assert_called_with(size=12)
-        root.tk_setPalette.assert_called()
+        root.tk_setPalette.assert_called_with(background="white")
         gui_obj.update_display.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- store the default Tk background color at init
- restore it when disabling high contrast
- adjust unit tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7d16b26483268bd864fd0dce6ce8