### PR TITLE
Introduce AI difficulty tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The GUI supports a few convenience features:
 - Press **Enter** to play the currently selected cards or **Space** to pass.
 - Resize the window or press **F11** to toggle full‑screen mode and the
   card buttons will scale accordingly.
+- Adjust AI difficulty (Easy/Normal/Hard) from the **Options > Settings** dialog.
 
 Displaying card images requires the **Pillow** library, which is
 included in `requirements.txt`. Install dependencies (including Pillow

--- a/gui.py
+++ b/gui.py
@@ -48,9 +48,8 @@ class GameGUI:
         self.card_font = tkfont.Font(size=12)
         self.game = Game()
         self.game.setup()
-        # Difficulty multiplier affecting AI aggressiveness
-        self.ai_difficulty = 1.0
-        self.game.ai_difficulty = self.ai_difficulty
+        # AI difficulty tier
+        self.set_ai_level("Normal")
         self.high_contrast = False
 
         # Load sound effects and background music
@@ -180,6 +179,14 @@ class GameGUI:
         self.update_display()
         self.show_menu()
         self.root.after(100, self.game_loop)
+
+    def set_ai_level(self, level: str) -> None:
+        """Set difficulty tier for the AI opponents."""
+
+        mapping = {"Easy": 0.5, "Normal": 1.0, "Hard": 2.0}
+        self.ai_level = level
+        self.ai_difficulty = mapping.get(level, 1.0)
+        self.game.set_ai_level(level)
 
     def on_selection(self, selection: set) -> None:
         """Callback from :class:`HandView` when the selection changes."""
@@ -396,7 +403,7 @@ class GameGUI:
                 data = f.read()
             new_game = Game()
             new_game.from_json(data)
-            new_game.ai_difficulty = self.ai_difficulty
+            new_game.set_ai_level(self.ai_level)
             self.game = new_game
             self.table_view.game = self.game
             self.hand_view.game = self.game
@@ -433,7 +440,7 @@ class GameGUI:
         orig_game = self.game
         replay_game = Game()
         replay_game.from_json(state)
-        replay_game.ai_difficulty = self.ai_difficulty
+        replay_game.set_ai_level(self.ai_level)
         self.game = replay_game
         self.table_view.game = self.game
         self.hand_view.game = self.game

--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -51,11 +51,11 @@ class SettingsDialog(tk.Toplevel):
         self.no2_var = tk.BooleanVar(value=not rules.ALLOW_2_IN_SEQUENCE)
         tk.Checkbutton(frame, text="Disallow 2 in sequences", variable=self.no2_var).pack(anchor="w")
 
-        # AI difficulty slider
+        # AI difficulty tier
         tk.Label(frame, text="AI difficulty").pack(anchor="w")
-        self.diff_var = tk.DoubleVar(value=self.gui.ai_difficulty)
-        tk.Scale(frame, from_=0.5, to=3.0, resolution=0.1, orient=tk.HORIZONTAL,
-                 variable=self.diff_var).pack(anchor="w")
+        levels = ["Easy", "Normal", "Hard"]
+        self.diff_var = tk.StringVar(value=self.gui.ai_level)
+        ttk.OptionMenu(frame, self.diff_var, self.gui.ai_level, *levels).pack(anchor="w")
 
         # Accessibility
         self.hc_var = tk.BooleanVar(value=self.gui.high_contrast)
@@ -92,8 +92,7 @@ class SettingsDialog(tk.Toplevel):
                 self.gui.root.iconphoto(False, img)
             except Exception:
                 pass
-        diff = float(self.diff_var.get())
-        self.gui.ai_difficulty = diff
-        self.gui.game.ai_difficulty = diff
+        level = self.diff_var.get()
+        self.gui.set_ai_level(level)
         self.gui.set_high_contrast(self.hc_var.get())
         self.destroy()

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -181,8 +181,16 @@ class Game:
         self.round_states: dict[int, str] = {}
         self.current_round = 1
         self.scores: dict[str, int] = {p.name: 0 for p in self.players}
-        # Multiplier influencing how aggressively the AI plays
+        # AI difficulty tier and numeric multiplier
+        self.ai_level = "Normal"
         self.ai_difficulty = 1.0
+
+    def set_ai_level(self, level: str) -> None:
+        """Set difficulty tier and adjust internal multiplier."""
+
+        mapping = {"Easy": 0.5, "Normal": 1.0, "Hard": 2.0}
+        self.ai_level = level
+        self.ai_difficulty = mapping.get(level, 1.0)
 
     def setup(self):
         """Shuffle, deal and determine the starting player."""
@@ -364,6 +372,9 @@ class Game:
         remaining = [c for c in player.hand if c not in move]
         finish = 1 if not remaining else 0
         diff = getattr(self, "ai_difficulty", 1.0)
+        if self.ai_level == "Hard":
+            low_cards = -sum(RANKS.index(c.rank) for c in remaining)
+            return (base, finish * diff, rank_val * diff, low_cards)
         return (base, finish * diff, rank_val * diff)
 
     def ai_play(self, current):
@@ -373,6 +384,8 @@ class Game:
         moves = self.generate_valid_moves(p, current)
         if not moves:
             return []
+        if self.ai_level == "Easy":
+            return random.choice(moves)
         return max(moves, key=lambda m: self.score_move(p, m, current))
 
     # Display functions


### PR DESCRIPTION
## Summary
- add AI level attribute and set_ai_level helper to Game
- choose random moves on Easy AI and better heuristics on Hard
- expose difficulty tiers via GUI and settings dialog
- document difficulty option in README

## Testing
- `pip install -r requirements.txt`
- `coverage run -m pytest`
- `coverage xml`


------
https://chatgpt.com/codex/tasks/task_e_68503f17fcec832693f81b536e3aaec7