### PR TITLE
Add AI difficulty CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ After installation launch the GUI simply by running `tien-len`.
 To play in the terminal run:
 
 ```bash
-python3 tien_len_full.py
+python3 tien_len_full.py [--ai Easy|Normal|Hard]
 ```
 
+The optional `--ai` flag selects the AI difficulty (default is `Normal`).
 The game logs actions to `tien_len_game.log`.
 
 ## GUI prototype

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -16,6 +16,7 @@ decisions:
 import random
 import datetime
 import sys
+import argparse
 import sound
 from collections import Counter
 from itertools import combinations
@@ -634,4 +635,11 @@ class Game:
         self.current_idx = (self.current_idx + 1) % len(self.players)
 
 if __name__ == '__main__':
-    Game().play()
+    parser = argparse.ArgumentParser(description='Play Tiến Lên in the terminal')
+    parser.add_argument('--ai', default='Normal', choices=['Easy', 'Normal', 'Hard'],
+                        help='AI difficulty level')
+    args = parser.parse_args()
+
+    game = Game()
+    game.set_ai_level(args.ai)
+    game.play()


### PR DESCRIPTION
## Summary
- support `--ai` CLI option in `tien_len_full.py`
- document new argument in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505645dd8883269a5595d3abbb4b2a