### PR TITLE
Use scoring for human hints

### DIFF
--- a/tests/test_hint.py
+++ b/tests/test_hint.py
@@ -1,0 +1,38 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from tien_len_full import Game, Card, detect_combo
+
+
+def test_hint_recommends_pair_over_single():
+    game = Game()
+    p = game.players[0]
+    c1 = Card('Spades', '3')
+    c2 = Card('Hearts', '3')
+    c3 = Card('Diamonds', '4')
+    p.hand = [c1, c2, c3]
+    game.current_idx = 0
+    game.start_idx = 0
+    game.first_turn = True
+
+    hint = game.hint(None)
+    assert set(hint) == {c1, c2}
+    assert detect_combo(hint) == 'pair'
+
+
+def test_hint_ignores_ai_difficulty():
+    game = Game()
+    game.set_ai_level('Hard')
+    p = game.players[0]
+    c1 = Card('Spades', '3')
+    c2 = Card('Hearts', '3')
+    c3 = Card('Diamonds', '4')
+    p.hand = [c1, c2, c3]
+    game.current_idx = 0
+    game.start_idx = 0
+    game.first_turn = True
+
+    hint = game.hint(None)
+    assert set(hint) == {c1, c2}
+

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -307,13 +307,25 @@ class Game:
         return 'play', cards
 
     def hint(self, current):
-        """Return a simple hint for the human player."""
+        """Return a suggested move for the human player."""
 
-        for c in self.players[0].hand:
-            ok, _ = self.is_valid(self.players[0], [c], current)
-            if ok:
-                return [c]
-        return []
+        player = self.players[0]
+        moves = self.generate_valid_moves(player, current)
+        if not moves:
+            return []
+
+        # Evaluate moves using ``score_move`` but without any AI difficulty
+        # modifiers so the recommendation remains neutral regardless of the
+        # configured AI level.
+        orig_level = getattr(self, "ai_level", "Normal")
+        orig_diff = getattr(self, "ai_difficulty", 1.0)
+        self.ai_level = "Normal"
+        self.ai_difficulty = 1.0
+        try:
+            return max(moves, key=lambda m: self.score_move(player, m, current))
+        finally:
+            self.ai_level = orig_level
+            self.ai_difficulty = orig_diff
 
     def cli_input(self, current):
         """Prompt the human player for a move on the command line."""


### PR DESCRIPTION
## Summary
- enhance `Game.hint` to evaluate all valid moves with `score_move`
- keep AI settings from influencing human hints
- add tests covering hint scoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685057572ddc8326bcffdcfd9e6a1176