### PR TITLE
Ensure score_move consistent tuple size

### DIFF
--- a/tests/test_score_move.py
+++ b/tests/test_score_move.py
@@ -1,0 +1,20 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from tien_len_full import Game, Card, RANKS
+
+
+def test_score_move_tuple_length_and_low_cards():
+    game = Game()
+    ai = game.players[1]
+    ai.hand = [Card('Spades', '3'), Card('Hearts', '4')]
+    move = [ai.hand[0]]
+    normal_score = game.score_move(ai, move, None)
+    assert len(normal_score) == 4
+    assert normal_score[-1] == 0
+
+    game.set_ai_level('Hard')
+    hard_score = game.score_move(ai, move, None)
+    assert len(hard_score) == 4
+    assert hard_score[-1] == -RANKS.index('4')

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -385,10 +385,10 @@ class Game:
         remaining = [c for c in player.hand if c not in move]
         finish = 1 if not remaining else 0
         diff = getattr(self, "ai_difficulty", 1.0)
+        low_cards = 0
         if self.ai_level == "Hard":
             low_cards = -sum(RANKS.index(c.rank) for c in remaining)
-            return (base, finish * diff, rank_val * diff, low_cards)
-        return (base, finish * diff, rank_val * diff)
+        return (base, finish * diff, rank_val * diff, low_cards)
 
     def ai_play(self, current):
         """Choose a move for the current AI player."""


### PR DESCRIPTION
## Summary
- always return four elements from `score_move`
- add unit test verifying tuple length for all AI levels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685060c6f12483268170490c3665d826