### PR TITLE
Add hint button and functionality

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -134,9 +134,12 @@ class GameGUI:
         self.pass_btn.pack(side=tk.LEFT)
         self.sort_btn = tk.Button(action_frame, text="Sort Hand", command=self.sort_hand)
         self.sort_btn.pack(side=tk.LEFT)
+        self.hint_btn = tk.Button(action_frame, text="Hint", command=self.show_hint)
+        self.hint_btn.pack(side=tk.LEFT)
         ToolTip(self.play_btn, "Drag to play")
         ToolTip(self.pass_btn, "Drag to play")
         ToolTip(self.sort_btn, "Drag to play")
+        ToolTip(self.hint_btn, "Suggest a move")
 
         # Indicator shown when AI players are thinking
         self.thinking = tk.Label(
@@ -171,6 +174,7 @@ class GameGUI:
         # Keyboard shortcuts
         self.root.bind("<Return>", lambda e: self.play_selected())
         self.root.bind("<space>", lambda e: self.pass_turn())
+        self.root.bind("<h>", lambda e: self.show_hint())
         self.root.bind("<F11>", lambda e: self.toggle_fullscreen())
         self.root.bind("<Escape>", lambda e: self.end_fullscreen())
         self.root.bind("<Configure>", self.on_resize)
@@ -344,6 +348,9 @@ class GameGUI:
         )
         self.pass_btn.config(
             state=tk.NORMAL if is_human_turn and pass_ok else tk.DISABLED
+        )
+        self.hint_btn.config(
+            state=tk.NORMAL if is_human_turn else tk.DISABLED
         )
 
         self.update_sidebar()
@@ -693,6 +700,15 @@ class GameGUI:
         self.game.players[0].sort_hand()
         self.selected.clear()
         self.update_display()
+
+    def show_hint(self):
+        """Display a suggested move for the player."""
+        hint = self.game.hint(self.game.current_combo)
+        if hint:
+            msg = "Suggested move: " + ", ".join(map(str, hint))
+        else:
+            msg = "No valid moves available"
+        messagebox.showinfo("Hint", msg)
 
     # Main game loop ---------------------------------------------
     def game_loop(self):

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -72,3 +72,41 @@ def test_show_menu_overlay():
         overlay.place.assert_called_with(relx=0, rely=0, relwidth=1, relheight=1)
         assert mock_button.call_count >= 4
 
+
+def test_show_hint_calls_game_and_displays():
+    root = MagicMock()
+    gui_obj = make_gui_stub(root)
+    gui_obj.game = MagicMock()
+    gui_obj.game.current_combo = None
+    gui_obj.game.hint.return_value = ['A', 'B']
+    with patch('gui.messagebox.showinfo') as mock_info:
+        gui_obj.show_hint()
+        gui_obj.game.hint.assert_called_with(gui_obj.game.current_combo)
+        mock_info.assert_called_once()
+
+
+def test_update_display_disables_hint_for_ai_turn():
+    root = MagicMock()
+    gui_obj = make_gui_stub(root)
+    gui_obj.update_display = gui.GameGUI.update_display.__get__(gui_obj)
+    gui_obj.table_view = MagicMock()
+    gui_obj.hand_view = MagicMock()
+    gui_obj.info_var = MagicMock()
+    gui_obj.turn_label = MagicMock()
+    gui_obj.turn_var = MagicMock()
+    gui_obj.play_btn = MagicMock()
+    gui_obj.pass_btn = MagicMock()
+    gui_obj.hint_btn = MagicMock()
+    gui_obj.update_sidebar = MagicMock()
+    human = MagicMock(is_human=True, name='Human')
+    ai = MagicMock(is_human=False, name='AI')
+    gui_obj.game = MagicMock()
+    gui_obj.game.players = [human, ai]
+    gui_obj.game.current_idx = 1  # AI's turn
+    gui_obj.game.current_combo = None
+    gui_obj.selected = set()
+    gui_obj.game.is_valid.return_value = (True, '')
+
+    gui_obj.update_display()
+    gui_obj.hint_btn.config.assert_called_with(state=gui.tk.DISABLED)
+


### PR DESCRIPTION
## Summary
- add Hint button with keyboard shortcut
- implement `show_hint` to display suggested cards
- disable hint button when not player's turn
- test GUI hint features

## Testing
- `pip install -q pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685069d746e883268a7a5de8cda4274e