### PR TITLE
Add rankings overlay

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -610,6 +610,9 @@ class GameGUI:
         box = tk.Frame(overlay, bg="white", bd=2, relief=tk.RIDGE)
         box.place(relx=0.5, rely=0.5, anchor="center")
         tk.Label(box, text=f"\U0001f389 {winner} wins!", font=("Arial", 16)).pack(padx=20, pady=(10, 5))
+        ranks = self.game.get_rankings()
+        rank_lines = [f"{i+1}. {n} ({c})" for i, (n, c) in enumerate(ranks)]
+        tk.Label(box, text="\n".join(rank_lines), justify=tk.LEFT).pack(padx=20, pady=(0, 5))
         btn_frame = tk.Frame(box, bg="white")
         btn_frame.pack(pady=(0, 10))
         tk.Button(btn_frame, text="Play Again", command=lambda: self.play_again(overlay)).pack(side=tk.LEFT, padx=5)

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -110,3 +110,28 @@ def test_update_display_disables_hint_for_ai_turn():
     gui_obj.update_display()
     gui_obj.hint_btn.config.assert_called_with(state=gui.tk.DISABLED)
 
+
+def test_show_game_over_displays_rankings():
+    root = MagicMock()
+    gui_obj = make_gui_stub(root)
+    gui_obj.game = MagicMock()
+    gui_obj.game.get_rankings.return_value = [('Alice', 0), ('Bob', 3)]
+
+    overlay = MagicMock()
+    box = MagicMock()
+    btn_frame = MagicMock()
+    with patch('gui.tk.Frame', side_effect=[overlay, box, btn_frame]) as mock_frame, \
+         patch('gui.tk.Label') as mock_label, \
+         patch('gui.tk.Button') as mock_button, \
+         patch('gui.sound.play'), \
+         patch.object(gui.GameGUI, '_sparkle'):
+        gui_obj.show_game_over('Alice')
+
+        mock_frame.assert_any_call(gui_obj.root, bg='#00000080')
+        overlay.place.assert_called_with(relx=0, rely=0, relwidth=1, relheight=1)
+        gui_obj.game.get_rankings.assert_called_once()
+
+        texts = [kwargs.get('text', '') for _, kwargs in mock_label.call_args_list]
+        assert any('Alice' in t and 'Bob' in t for t in texts)
+        assert mock_button.call_count >= 2
+


### PR DESCRIPTION
## Summary
- show player rankings in the game over screen
- test game over overlay ranking info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506b8406a48326a0fa188262f36539