### PR TITLE
Add interactive tutorial window

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -421,19 +421,78 @@ class GameGUI:
             messagebox.showerror("Load Failed", str(exc))
 
     def show_rules(self):
-        """Display a modal window with basic rules."""
+        """Display a multi-page tutorial explaining the rules."""
+
         win = tk.Toplevel(self.root)
-        win.title("Game Rules")
+        win.title("Game Tutorial")
         win.transient(self.root)
         win.grab_set()
-        text = (
-            "Each player is dealt 13 cards.\n"
-            "On your turn play a higher combo or pass.\n"
-            "The first player to shed all cards wins.\n\n"
-            "Example: play a pair of 7s over a pair of 5s."
-        )
-        tk.Label(win, text=text, justify=tk.LEFT, wraplength=400).pack(padx=20, pady=20)
-        tk.Button(win, text="Close", command=win.destroy).pack(pady=(0, 10))
+
+        pages: list[tk.Frame] = []
+
+        # Page 1: basic objective
+        p1 = tk.Frame(win)
+        tk.Label(
+            p1,
+            text=(
+                "Objective:\n"
+                "Be the first to shed all of your cards.\n"
+                "Beat the current combo or pass if you cannot."),
+            justify=tk.LEFT,
+            wraplength=400,
+        ).pack(padx=20, pady=20)
+        pages.append(p1)
+
+        # Page 2: combo examples
+        p2 = tk.Frame(win)
+        tk.Label(
+            p2,
+            text="Valid combinations include singles, pairs, triples, "
+                 "sequences and bombs.",
+            justify=tk.LEFT,
+            wraplength=400,
+        ).pack(padx=20, pady=(10, 5))
+        pages.append(p2)
+
+        # Page 3: controls
+        p3 = tk.Frame(win)
+        tk.Label(
+            p3,
+            text=(
+                "Controls:\n"
+                "Select cards with the mouse and press Play or Enter.\n"
+                "Press Pass or Space to skip your turn."),
+            justify=tk.LEFT,
+            wraplength=400,
+        ).pack(padx=20, pady=20)
+        pages.append(p3)
+
+        nav = tk.Frame(win)
+        nav.pack(side=tk.BOTTOM, pady=10)
+        prev_btn = tk.Button(nav, text="Prev")
+        prev_btn.pack(side=tk.LEFT, padx=5)
+        next_btn = tk.Button(nav, text="Next")
+        next_btn.pack(side=tk.LEFT, padx=5)
+        tk.Button(nav, text="Close", command=win.destroy).pack(side=tk.LEFT, padx=5)
+
+        def show(idx: int) -> None:
+            for f in pages:
+                f.pack_forget()
+            pages[idx].pack(fill=tk.BOTH, expand=True)
+            prev_btn.config(state=tk.NORMAL if idx > 0 else tk.DISABLED)
+            next_btn.config(state=tk.NORMAL if idx < len(pages) - 1 else tk.DISABLED)
+            win.current = idx
+
+        def next_page() -> None:
+            show(min(win.current + 1, len(pages) - 1))
+
+        def prev_page() -> None:
+            show(max(win.current - 1, 0))
+
+        prev_btn.config(command=prev_page)
+        next_btn.config(command=next_page)
+        win.current = 0
+        show(0)
 
     def replay_last_round(self):
         """Replay the most recently completed round using animations."""
@@ -629,6 +688,7 @@ class GameGUI:
         tk.Label(box, text="Tiến Lên", font=("Arial", 16, "bold")).pack(padx=20, pady=(10, 5))
         tk.Button(box, text="New Game", command=self.menu_new_game).pack(fill="x", padx=20, pady=5)
         tk.Button(box, text="Load Game", command=self.menu_load_game).pack(fill="x", padx=20, pady=5)
+        tk.Button(box, text="Start Tutorial", command=self.show_rules).pack(fill="x", padx=20, pady=5)
         tk.Button(box, text="Options", command=self.open_settings).pack(fill="x", padx=20, pady=5)
         tk.Button(box, text="Quit", command=self.root.destroy).pack(fill="x", padx=20, pady=(5, 10))
 

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -14,6 +14,8 @@ def make_gui_stub(root):
     g._default_bg = "white"
     g.card_font = MagicMock()
     g.update_display = MagicMock()
+    g.base_images = {}
+    g.scaled_images = {}
     return g
 
 
@@ -48,15 +50,16 @@ def test_show_rules_creates_modal():
     gui_obj = make_gui_stub(root)
     win = MagicMock()
     with patch('gui.tk.Toplevel', return_value=win) as mock_top, \
+         patch('gui.tk.Frame') as mock_frame, \
          patch('gui.tk.Label') as mock_label, \
          patch('gui.tk.Button') as mock_button:
         gui_obj.show_rules()
         mock_top.assert_called_with(gui_obj.root)
-        win.title.assert_called_with('Game Rules')
+        win.title.assert_called_with('Game Tutorial')
         win.transient.assert_called_with(gui_obj.root)
         win.grab_set.assert_called_once()
-        mock_label.assert_called()
-        mock_button.assert_called()
+        assert mock_frame.call_count >= 1
+        assert mock_button.call_count >= 3
 
 
 def test_show_menu_overlay():
@@ -71,6 +74,19 @@ def test_show_menu_overlay():
         mock_frame.assert_any_call(gui_obj.root, bg='#00000080')
         overlay.place.assert_called_with(relx=0, rely=0, relwidth=1, relheight=1)
         assert mock_button.call_count >= 4
+
+
+def test_menu_includes_tutorial_button():
+    root = MagicMock()
+    gui_obj = make_gui_stub(root)
+    overlay = MagicMock()
+    box = MagicMock()
+    with patch('gui.tk.Frame', side_effect=[overlay, box]) as mock_frame, \
+         patch('gui.tk.Label'), \
+         patch('gui.tk.Button') as mock_button:
+        gui_obj.show_menu()
+        texts = [kwargs.get('text', '') for _, kwargs in mock_button.call_args_list]
+        assert 'Start Tutorial' in texts
 
 
 def test_show_hint_calls_game_and_displays():


### PR DESCRIPTION
## Summary
- expand `show_rules` into a simple multi-page tutorial window
- include a new "Start Tutorial" option in the main menu
- adjust GUI tests for the updated tutorial window and menu

## Testing
- `pip install -q -r requirements.txt`
- `coverage run -m pytest`
- `coverage xml`

------
https://chatgpt.com/codex/tasks/task_e_68506e6af35c8326860dc2eb7b2e1005