### PR TITLE
Implement undo history and GUI button

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -176,10 +176,13 @@ class GameGUI:
         self.sort_btn.pack(side=tk.LEFT)
         self.hint_btn = tk.Button(action_frame, text="Hint", command=self.show_hint)
         self.hint_btn.pack(side=tk.LEFT)
+        self.undo_btn = tk.Button(action_frame, text="Undo", command=self.undo_move)
+        self.undo_btn.pack(side=tk.LEFT)
         ToolTip(self.play_btn, "Drag to play")
         ToolTip(self.pass_btn, "Drag to play")
         ToolTip(self.sort_btn, "Drag to play")
         ToolTip(self.hint_btn, "Suggest a move")
+        ToolTip(self.undo_btn, "Undo last move")
 
         # Indicator shown when AI players are thinking
         self.thinking = tk.Label(
@@ -417,6 +420,9 @@ class GameGUI:
         self.hint_btn.config(
             state=tk.NORMAL if is_human_turn else tk.DISABLED
         )
+        self.undo_btn.config(
+            state=tk.NORMAL if len(self.game.snapshots) > 1 else tk.DISABLED
+        )
 
         self.update_sidebar()
 
@@ -476,6 +482,7 @@ class GameGUI:
             new_game = Game()
             new_game.from_json(data)
             new_game.set_ai_level(self.ai_level)
+            new_game.snapshots = [new_game.to_json()]
             self.game = new_game
             self.table_view.game = self.game
             self.hand_view.game = self.game
@@ -823,6 +830,14 @@ class GameGUI:
         self.game.next_turn()
         self.selected.clear()
         self.update_display()
+
+    def undo_move(self):
+        """Undo the most recent move if possible."""
+
+        if self.game.undo_last():
+            self.selected.clear()
+            self.update_sidebar()
+            self.update_display()
 
     def sort_hand(self):
         self.game.players[0].sort_hand(self.sort_mode)

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -13,6 +13,7 @@ def make_gui_stub(root):
     g.root.cget = MagicMock(return_value="white")
     g._default_bg = "white"
     g.card_font = MagicMock()
+    g.undo_btn = MagicMock()
     g.update_display = MagicMock()
     g.base_images = {}
     g.scaled_images = {}
@@ -150,4 +151,34 @@ def test_show_game_over_displays_rankings():
         texts = [kwargs.get('text', '') for _, kwargs in mock_label.call_args_list]
         assert any('Alice' in t and 'Bob' in t for t in texts)
         assert mock_button.call_count >= 2
+
+
+def test_update_display_sets_undo_state():
+    root = MagicMock()
+    gui_obj = make_gui_stub(root)
+    gui_obj.update_display = gui.GameGUI.update_display.__get__(gui_obj)
+    gui_obj.table_view = MagicMock()
+    gui_obj.hand_view = MagicMock()
+    gui_obj.info_var = MagicMock()
+    gui_obj.turn_label = MagicMock()
+    gui_obj.turn_var = MagicMock()
+    gui_obj.play_btn = MagicMock()
+    gui_obj.pass_btn = MagicMock()
+    gui_obj.hint_btn = MagicMock()
+    gui_obj.update_sidebar = MagicMock()
+    player = MagicMock(is_human=True, name='Player')
+    gui_obj.game = MagicMock()
+    gui_obj.game.players = [player]
+    gui_obj.game.current_idx = 0
+    gui_obj.game.current_combo = None
+    gui_obj.game.is_valid.return_value = (True, '')
+    gui_obj.selected = set()
+
+    gui_obj.game.snapshots = ['s1']
+    gui_obj.update_display()
+    gui_obj.undo_btn.config.assert_called_with(state=gui.tk.DISABLED)
+
+    gui_obj.game.snapshots.append('s2')
+    gui_obj.update_display()
+    gui_obj.undo_btn.config.assert_called_with(state=gui.tk.NORMAL)
 

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -1,0 +1,40 @@
+import pytest
+from tien_len_full import Game, Card
+
+
+def test_undo_play_restores_state():
+    game = Game()
+    p = game.players[0]
+    p.hand = [Card('Spades', '3'), Card('Hearts', '4')]
+    game.current_idx = 0
+    game.start_idx = 0
+    game.first_turn = True
+    game.snapshots = [game.to_json()]
+
+    game.process_play(p, [p.hand[0]])
+    assert len(game.snapshots) == 2
+    assert len(game.players[0].hand) == 1
+    assert game.pile
+
+    assert game.undo_last() is True
+    assert len(game.snapshots) == 1
+    assert not game.pile
+    assert len(game.players[0].hand) == 2
+    assert game.first_turn is True
+
+
+def test_undo_pass_restores_state():
+    game = Game()
+    game.players[0].hand = [Card('Spades', '3')]
+    game.current_idx = 0
+    game.start_idx = 1  # allow pass on first turn
+    game.first_turn = False
+    game.snapshots = [game.to_json()]
+
+    game.process_pass(game.players[0])
+    assert len(game.snapshots) == 2
+    assert game.pass_count == 1
+
+    assert game.undo_last() is True
+    assert len(game.snapshots) == 1
+    assert game.pass_count == 0


### PR DESCRIPTION
## Summary
- capture state after each play/pass for undo functionality
- allow game state to be rolled back via `Game.undo_last`
- add Undo button to the Tkinter GUI and enable/disable appropriately
- test undo logic and button behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507110fe388326a38ce92b00dd2c59