### PR TITLE
Add AI personality and lookahead features

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The GUI supports a few convenience features:
 - Resize the window or press **F11** to toggle full‑screen mode and the
   card buttons will scale accordingly.
 - Adjust AI difficulty (Easy/Normal/Hard) from the **Options > Settings** dialog.
+- Pick an AI personality (Aggressive/Defensive/Random) and toggle lookahead for
+  Hard difficulty from the same dialog.
 
 Displaying card images requires the **Pillow** library, which is
 included in `requirements.txt`. Install dependencies (including Pillow

--- a/gui.py
+++ b/gui.py
@@ -38,6 +38,9 @@ class GameGUI:
             "card_back": self.card_back_name,
             "sort_mode": self.sort_mode,
             "player_name": self.player_name,
+            "ai_level": self.ai_level,
+            "ai_personality": getattr(self, "ai_personality", "balanced"),
+            "ai_lookahead": getattr(self, "ai_lookahead", False),
         }
         try:
             with open(self.OPTIONS_FILE, "w", encoding="utf-8") as f:
@@ -86,8 +89,11 @@ class GameGUI:
         self.card_back_name = opts.get("card_back", "card_back")
         self.player_name = opts.get("player_name", "Player")
         self.table_cloth_color = opts.get("table_color", "darkgreen")
-        # AI difficulty tier
-        self.set_ai_level("Normal")
+        # AI difficulty and personality
+        self.set_ai_level(opts.get("ai_level", "Normal"))
+        self.ai_lookahead = opts.get("ai_lookahead", False)
+        self.set_personality(opts.get("ai_personality", "balanced"))
+        self.game.ai_lookahead = self.ai_lookahead
         self.high_contrast = False
 
         # Load sound effects and background music
@@ -248,6 +254,9 @@ class GameGUI:
         if old != self.player_name:
             self.game.scores[self.player_name] = self.game.scores.pop(old, 0)
         self.game.players[0].sort_hand(self.sort_mode)
+        self.set_ai_level(self.ai_level)
+        self.set_personality(getattr(self, "ai_personality", "balanced"))
+        self.game.ai_lookahead = getattr(self, "ai_lookahead", False)
         self.update_display()
         self.update_sidebar()
 
@@ -258,6 +267,12 @@ class GameGUI:
         self.ai_level = level
         self.ai_difficulty = mapping.get(level, 1.0)
         self.game.set_ai_level(level)
+
+    def set_personality(self, name: str) -> None:
+        """Set AI personality preset."""
+
+        self.ai_personality = name
+        self.game.set_personality(name)
 
     def on_selection(self, selection: set) -> None:
         """Callback from :class:`HandView` when the selection changes."""

--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -63,6 +63,15 @@ class SettingsDialog(tk.Toplevel):
         self.diff_var = tk.StringVar(value=self.gui.ai_level)
         ttk.OptionMenu(frame, self.diff_var, self.gui.ai_level, *levels).pack(anchor="w")
 
+        # AI personality preset
+        tk.Label(frame, text="AI personality").pack(anchor="w")
+        personalities = ["Aggressive", "Defensive", "Random"]
+        cur_pers = getattr(self.gui, "ai_personality", "balanced").title()
+        self.pers_var = tk.StringVar(value=cur_pers)
+        ttk.OptionMenu(frame, self.pers_var, cur_pers, *personalities).pack(anchor="w")
+        self.lookahead_var = tk.BooleanVar(value=getattr(self.gui, "ai_lookahead", False))
+        tk.Checkbutton(frame, text="Enable lookahead (Hard)", variable=self.lookahead_var).pack(anchor="w")
+
         # Animation speed
         tk.Label(frame, text="Animation speed").pack(anchor="w")
         speeds = ["Slow", "Normal", "Fast"]
@@ -120,6 +129,8 @@ class SettingsDialog(tk.Toplevel):
         self.gui.player_name = self.name_var.get() or "Player"
         level = self.diff_var.get()
         self.gui.set_ai_level(level)
+        self.gui.ai_lookahead = self.lookahead_var.get()
+        self.gui.set_personality(self.pers_var.get().lower())
         self.gui.set_high_contrast(self.hc_var.get())
         self.gui.apply_options()
         self.gui.save_options()


### PR DESCRIPTION
## Summary
- support AI personalities and lookahead for hard difficulty
- allow bluffing/pass behaviour for AI
- expose new options in settings dialog

## Testing
- `pip install -q pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685072ec1c808326b5d5d8635e9b9b2c