### PR TITLE
Fix high contrast fallback

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -16,6 +16,9 @@ try:
 except ImportError:  # pragma: no cover - pygame optional
     pygame = None
 
+# Fallback color used if the root window returns an empty background value
+DEFAULT_BG_FALLBACK = "#d9d9d9"
+
 
 class GameGUI:
     CARD_WIDTH = 80
@@ -52,7 +55,8 @@ class GameGUI:
         self.root = root
         self.root.title("Tiến Lên GUI Prototype")
         # Capture the window's default background color so we can restore it
-        self._default_bg = self.root.cget("background")
+        bg = self.root.cget("background")
+        self._default_bg = bg or DEFAULT_BG_FALLBACK
         # Setup menu bar
         menubar = tk.Menu(self.root)
         self.root.config(menu=menubar)
@@ -360,7 +364,8 @@ class GameGUI:
                                    activeForeground="white")
         else:
             # Restore the palette to the window's original background color
-            self.root.tk_setPalette(background=self._default_bg)
+            bg = self._default_bg or DEFAULT_BG_FALLBACK
+            self.root.tk_setPalette(background=bg)
         self.update_display()
 
     def on_resize(self, event):

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -45,6 +45,20 @@ def test_set_high_contrast_toggle():
         root.tk_setPalette.assert_called_with(background="white")
         gui_obj.update_display.assert_called_once()
 
+        # Empty default background should fall back to constant
+        root.reset_mock()
+        default_font.configure.reset_mock()
+        gui_obj.card_font.configure.reset_mock()
+        gui_obj.update_display.reset_mock()
+
+        gui_obj._default_bg = ""
+        gui_obj.set_high_contrast(False)
+        assert gui_obj.high_contrast is False
+        default_font.configure.assert_called_with(size=10)
+        gui_obj.card_font.configure.assert_called_with(size=12)
+        root.tk_setPalette.assert_called_with(background=gui.DEFAULT_BG_FALLBACK)
+        gui_obj.update_display.assert_called_once()
+
 
 def test_show_rules_creates_modal():
     root = MagicMock()


### PR DESCRIPTION
## Summary
- ensure `_default_bg` always has a valid color
- fall back to the default color in `set_high_contrast`
- check fallback handling in GUI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ad333fbc83269a6937890bcac1a7