### PR TITLE
Fix overlay color

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -757,7 +757,7 @@ class GameGUI:
         """Display a semi-transparent overlay with winner message."""
         sound.play("win")
         self.overlay_active = True
-        overlay = tk.Frame(self.root, bg="#00000080")
+        overlay = tk.Frame(self.root, bg="#000000")
         overlay.place(relx=0, rely=0, relwidth=1, relheight=1)
         box = tk.Frame(overlay, bg="white", bd=2, relief=tk.RIDGE)
         box.place(relx=0.5, rely=0.5, anchor="center")
@@ -774,7 +774,7 @@ class GameGUI:
     def show_menu(self):
         """Display the start menu with basic actions."""
         self.overlay_active = True
-        self.menu_overlay = tk.Frame(self.root, bg="#00000080")
+        self.menu_overlay = tk.Frame(self.root, bg="#000000")
         self.menu_overlay.place(relx=0, rely=0, relwidth=1, relheight=1)
         box = tk.Frame(self.menu_overlay, bg="white", bd=2, relief=tk.RIDGE)
         box.place(relx=0.5, rely=0.5, anchor="center")

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -86,7 +86,7 @@ def test_show_menu_overlay():
          patch('gui.tk.Label') as mock_label, \
          patch('gui.tk.Button') as mock_button:
         gui_obj.show_menu()
-        mock_frame.assert_any_call(gui_obj.root, bg='#00000080')
+        mock_frame.assert_any_call(gui_obj.root, bg='#000000')
         overlay.place.assert_called_with(relx=0, rely=0, relwidth=1, relheight=1)
         assert mock_button.call_count >= 4
 
@@ -158,7 +158,7 @@ def test_show_game_over_displays_rankings():
          patch.object(gui.GameGUI, '_sparkle'):
         gui_obj.show_game_over('Alice')
 
-        mock_frame.assert_any_call(gui_obj.root, bg='#00000080')
+        mock_frame.assert_any_call(gui_obj.root, bg='#000000')
         overlay.place.assert_called_with(relx=0, rely=0, relwidth=1, relheight=1)
         gui_obj.game.get_rankings.assert_called_once()
 


### PR DESCRIPTION
## Summary
- use 6-digit color codes for overlay frames
- update GUI tests for new color

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b22c12cc832681b23d48edd69697