### PR TITLE
Fix re-entrant resize loop

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -381,10 +381,16 @@ class GameGUI:
         self.update_display()
 
     def on_resize(self, event):
-        size = max(8, int(event.width / 50))
-        if size != self.card_font["size"]:
-            self.card_font.configure(size=size)
-        self.update_display()
+        if getattr(self, "_resizing", False):
+            return
+        self._resizing = True
+        try:
+            size = max(8, int(event.width / 50))
+            if size != self.card_font["size"]:
+                self.card_font.configure(size=size)
+            self.update_display()
+        finally:
+            self._resizing = False
         
     def _ease_out_quad(self, t: float) -> float:
         """Quadratic easing for smoother animations."""


### PR DESCRIPTION
## Summary
- protect `GameGUI.on_resize` from running recursively

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521f4015508326b7dcb5151b1c4f50