### PR TITLE
Fix replay causing invalid card references

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -634,8 +634,16 @@ class GameGUI:
             self.game.current_idx = idx
             p = self.game.players[idx]
             if typ == "play":
-                self.animate_play(cards)
-                self.game.process_play(p, list(cards))
+                converted = []
+                for d in cards:
+                    match = next(
+                        (c for c in p.hand if c.suit == d["suit"] and c.rank == d["rank"]),
+                        None,
+                    )
+                    if match:
+                        converted.append(match)
+                self.animate_play(converted)
+                self.game.process_play(p, converted)
             else:
                 self.animate_pass(p)
                 self.game.process_pass(p)

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -192,7 +192,8 @@ class Game:
         self.pass_count = 0
         self.current_combo: list[Card] | None = None
         self.history: list[tuple[int, str]] = []
-        self.move_log: dict[int, list[tuple[str, int, list[Card]]]] = {}
+        # Log of moves in each round using simple serialisable card dictionaries
+        self.move_log: dict[int, list[tuple[str, int, list[dict]]]] = {}
         self.round_states: dict[int, str] = {}
         self.current_round = 1
         self.scores: dict[str, int] = {p.name: 0 for p in self.players}
@@ -618,7 +619,7 @@ class Game:
         self.pass_count = 0
         self.history.append((self.current_round, f"{player.name} plays {cards}"))
         self.move_log.setdefault(self.current_round, []).append(
-            ("play", self.current_idx, list(cards))
+            ("play", self.current_idx, [self._card_to_dict(c) for c in cards])
         )
         for c in cards:
             player.hand.remove(c)


### PR DESCRIPTION
## Summary
- store move_log entries as card dictionaries instead of objects
- map stored card info back to the active hand when replaying

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522484d4348326a7cd2211775f6028