### PR TITLE
Improve card removal validation

### DIFF
--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -38,3 +38,12 @@ def test_undo_pass_restores_state():
     assert game.undo_last() is True
     assert len(game.snapshots) == 1
     assert game.pass_count == 0
+
+
+def test_process_play_invalid_card_raises():
+    game = Game()
+    player = game.players[0]
+    player.hand = [Card('Spades', '3')]
+    invalid = Card('Hearts', '4')
+    with pytest.raises(ValueError, match='not in hand'):
+        game.process_play(player, [invalid])

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -637,7 +637,7 @@ class Game:
         )
         for c in cards:
             if c not in player.hand:
-                print("Card not in hand:", c, "Current hand:", player.hand)
+                raise ValueError(f"Card {c} not in hand")
             player.hand.remove(c)
         self.pile.append((player, cards))
         self.current_combo = cards


### PR DESCRIPTION
## Summary
- raise ValueError if process_play is given a card not in player's hand
- test that invalid cards trigger an exception

## Testing
- `pip install pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e4fd1a448326baa832c34ce0f882