### PR TITLE
Add opponent views to GUI

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -8,7 +8,7 @@ import random
 import json
 
 from tien_len_full import Game, detect_combo, SUITS, RANKS
-from views import TableView, HandView
+from views import TableView, HandView, OpponentView
 from tooltip import ToolTip
 import sound
 try:
@@ -162,11 +162,43 @@ class GameGUI:
         self.sidebar = tk.Frame(root, bd=1, relief=tk.SUNKEN)
         self.sidebar.pack(side=tk.RIGHT, fill=tk.Y, padx=5, pady=5)
 
+        self.table_area = tk.Frame(self.main_area)
+        self.table_area.pack(pady=5)
+        self.top_opponent = OpponentView(
+            self.table_area,
+            self.game,
+            2,
+            self.base_images,
+            self.scaled_images,
+            self.CARD_WIDTH,
+        )
+        self.top_opponent.pack(side=tk.TOP)
+        middle = tk.Frame(self.table_area)
+        middle.pack()
+        self.left_opponent = OpponentView(
+            middle,
+            self.game,
+            1,
+            self.base_images,
+            self.scaled_images,
+            self.CARD_WIDTH,
+        )
+        self.left_opponent.pack(side=tk.LEFT, padx=5)
         self.table_view = TableView(
-            self.main_area, self.game, self.base_images, self.scaled_images, self.CARD_WIDTH
+            middle, self.game, self.base_images, self.scaled_images, self.CARD_WIDTH
         )
         self.table_view.config(bg=self.table_cloth_color)
-        self.table_view.pack(pady=5)
+        self.table_view.pack(side=tk.LEFT, padx=5)
+        self.right_opponent = OpponentView(
+            middle,
+            self.game,
+            3,
+            self.base_images,
+            self.scaled_images,
+            self.CARD_WIDTH,
+        )
+        self.right_opponent.pack(side=tk.LEFT, padx=5)
+        self.opponent_views = [self.left_opponent, self.top_opponent, self.right_opponent]
         tk.Label(self.main_area, textvariable=self.info_var).pack(pady=5)
         self.turn_label = tk.Label(self.main_area, textvariable=self.turn_var, font=("Arial", 12, "bold"))
         self.turn_label.pack(pady=2)
@@ -431,6 +463,8 @@ class GameGUI:
         self.table_view.refresh()
         self.hand_view.selected = set(self.selected)
         self.hand_view.refresh()
+        for v in self.opponent_views:
+            v.refresh()
 
         cur = self.game.players[self.game.current_idx]
         if cur.is_human:
@@ -524,6 +558,8 @@ class GameGUI:
             self.game = new_game
             self.table_view.game = self.game
             self.hand_view.game = self.game
+            for v in self.opponent_views:
+                v.game = self.game
             self.selected.clear()
             self.apply_options()
         except Exception as exc:
@@ -619,6 +655,8 @@ class GameGUI:
         self.game = replay_game
         self.table_view.game = self.game
         self.hand_view.game = self.game
+        for v in self.opponent_views:
+            v.game = self.game
         self.selected.clear()
         self.update_display()
 
@@ -627,6 +665,8 @@ class GameGUI:
                 self.game = orig_game
                 self.table_view.game = self.game
                 self.hand_view.game = self.game
+                for v in self.opponent_views:
+                    v.game = self.game
                 self.update_display()
                 self.update_sidebar()
                 return
@@ -836,6 +876,10 @@ class GameGUI:
         if scores:
             self.game.scores = scores
         self.game.setup()
+        self.table_view.game = self.game
+        self.hand_view.game = self.game
+        for v in self.opponent_views:
+            v.game = self.game
         self.selected.clear()
         self.apply_options()
 

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -17,6 +17,7 @@ def make_gui_stub(root):
     g.update_display = MagicMock()
     g.base_images = {}
     g.scaled_images = {}
+    g.opponent_views = []
     return g
 
 
@@ -195,4 +196,37 @@ def test_update_display_sets_undo_state():
     gui_obj.game.snapshots.append('s2')
     gui_obj.update_display()
     gui_obj.undo_btn.config.assert_called_with(state=gui.tk.NORMAL)
+
+
+def test_gui_initializes_opponent_views():
+    root = MagicMock()
+    root.cget = MagicMock(return_value="white")
+    with patch('gui.tk.Menu'), \
+         patch('gui.tk.Frame'), \
+         patch('gui.tk.Label'), \
+         patch('gui.tk.Button'), \
+         patch('gui.tk.Scale'), \
+         patch('gui.tk.StringVar'), \
+         patch('gui.tk.DoubleVar'), \
+         patch('gui.tkfont.Font'), \
+         patch.object(gui.GameGUI, 'load_images'), \
+         patch.object(gui.GameGUI, 'show_menu'), \
+         patch.object(gui.GameGUI, 'update_display'), \
+         patch('gui.TableView'), \
+         patch('gui.HandView'), \
+         patch('gui.OpponentView') as mock_opp, \
+         patch('gui.Game') as MockGame:
+        game = MagicMock()
+        game.setup = MagicMock()
+        players = [MagicMock(is_human=True, name='P', hand=[])]
+        players += [MagicMock(is_human=False, name=f'A{i}', hand=[]) for i in range(1,4)]
+        game.players = players
+        game.scores = {p.name: 0 for p in players}
+        MockGame.return_value = game
+        gui_obj = gui.GameGUI(root)
+        assert mock_opp.call_count == 3
+        assert hasattr(gui_obj, 'left_opponent')
+        assert hasattr(gui_obj, 'top_opponent')
+        assert hasattr(gui_obj, 'right_opponent')
+
 

--- a/views.py
+++ b/views.py
@@ -194,3 +194,40 @@ class HandView(tk.Frame):
             spr.pack(side=tk.LEFT, padx=2)
             self.widgets[c] = spr
         self.update_idletasks()
+class OpponentView(tk.Frame):
+    """Display an AI player's remaining cards."""
+
+    def __init__(self, master: tk.Widget, game: Game, idx: int,
+                 base_images: dict[str, Image.Image],
+                 cache: dict[tuple[str, int], ImageTk.PhotoImage],
+                 card_width: int = 80, **kwargs) -> None:
+        super().__init__(master, **kwargs)
+        self.game = game
+        self.idx = idx
+        self.base_images = base_images
+        self.cache = cache
+        self.card_width = card_width
+        self.count_var = tk.StringVar()
+        self.avatar = tk.Label(self, text=self.game.players[idx].name)
+        self.avatar.pack()
+        self.card_label = tk.Label(self)
+        self.card_label.pack()
+        tk.Label(self, textvariable=self.count_var).pack()
+        self.refresh()
+
+    def refresh(self) -> None:
+        player = self.game.players[self.idx]
+        self.count_var.set(str(len(player.hand)))
+        base = self.base_images.get("card_back")
+        if base is None:
+            self.card_label.config(text="[]")
+            return
+        key = ("card_back", self.card_width)
+        if key not in self.cache:
+            ratio = self.card_width / base.width
+            img = base.resize((self.card_width, int(base.height * ratio)), Image.LANCZOS)
+            self.cache[key] = ImageTk.PhotoImage(img)
+        img = self.cache[key]
+        self.card_label.config(image=img)
+        self.card_label.image = img
+


### PR DESCRIPTION
## Summary
- add `OpponentView` widget to display AI player info
- arrange opponent views around the table in `GameGUI`
- refresh opponent displays after each move
- create tests covering new widgets and adjust stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e607c9588326b65ddcb248e61cc4