### PR TITLE
Simplify test imports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Add repository root to Python path for tests
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -1,8 +1,5 @@
-import os
-import sys
 from unittest.mock import patch
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from tien_len_full import Game, Card
 
 

--- a/tests/test_hint.py
+++ b/tests/test_hint.py
@@ -1,7 +1,3 @@
-import os
-import sys
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from tien_len_full import Game, Card, detect_combo
 
 

--- a/tests/test_parse_input.py
+++ b/tests/test_parse_input.py
@@ -1,8 +1,5 @@
-import os
-import sys
 import pytest
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from tien_len_full import Game, Card
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,7 +1,3 @@
-import os
-import sys
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from tien_len_full import (
     Card,
     Player,

--- a/tests/test_score_move.py
+++ b/tests/test_score_move.py
@@ -1,7 +1,3 @@
-import os
-import sys
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from tien_len_full import Game, Card, RANKS
 
 


### PR DESCRIPTION
## Summary
- add a `conftest.py` that inserts the repo root into `sys.path`
- drop ad-hoc `sys.path.append` calls from tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68530a61d730832693b10765b499fb4b