### PR TITLE
Add animation speed control for Pygame GUI

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -151,16 +151,22 @@ class SettingsOverlay(Overlay):
         w, h = view.screen.get_size()
         font = view.font
         bx = w // 2 - 120
-        by = h // 2 - 60
+        by = h // 2 - 170
 
         def set_diff(level: str) -> Callable[[], None]:
             return lambda: view.set_ai_level(level)
+
+        def set_speed(speed: float) -> Callable[[], None]:
+            return lambda: setattr(view, 'animation_speed', speed)
 
         self.buttons = [
             Button('Easy AI', pygame.Rect(bx, by, 240, 40), set_diff('Easy'), font),
             Button('Normal AI', pygame.Rect(bx, by + 50, 240, 40), set_diff('Normal'), font),
             Button('Hard AI', pygame.Rect(bx, by + 100, 240, 40), set_diff('Hard'), font),
-            Button('Close', pygame.Rect(bx, by + 150, 240, 40), view.close_overlay, font),
+            Button('Slow Anim', pygame.Rect(bx, by + 150, 240, 40), set_speed(0.5), font),
+            Button('Normal Anim', pygame.Rect(bx, by + 200, 240, 40), set_speed(1.0), font),
+            Button('Fast Anim', pygame.Rect(bx, by + 250, 240, 40), set_speed(2.0), font),
+            Button('Close', pygame.Rect(bx, by + 300, 240, 40), view.close_overlay, font),
         ]
 
 
@@ -204,6 +210,7 @@ class GameView:
         pygame.display.set_caption("Tiến Lên - Pygame")
         self.screen = pygame.display.set_mode((width, height))
         self.clock = pygame.time.Clock()
+        self.animation_speed = 1.0
         self.game = Game()
         self.game.setup()
         self.font = pygame.font.SysFont(None, 24)
@@ -230,6 +237,7 @@ class GameView:
         """Move ``sprites`` toward ``dest`` over ``frames`` steps."""
         if not sprites:
             return
+        frames = max(1, int(frames / self.animation_speed))
         starts = [sp.rect.center for sp in sprites]
         for i in range(frames):
             t = (i + 1) / frames
@@ -247,6 +255,7 @@ class GameView:
         img = get_card_back()
         if img is None:
             return
+        frames = max(1, int(frames / self.animation_speed))
         rect = img.get_rect(center=start)
         for i in range(frames):
             t = (i + 1) / frames
@@ -265,6 +274,7 @@ class GameView:
         x, y = self._player_pos(idx)
         rect = pygame.Rect(0, 0, 140, 30)
         rect.center = (x, y - 40)
+        frames = max(1, int(frames / self.animation_speed))
         for i in range(frames):
             self._draw_frame()
             overlay = pygame.Surface(rect.size, pygame.SRCALPHA)

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -13,6 +13,26 @@ class DummyFont:
         return pygame.Surface((1, 1))
 
 
+class DummyClock:
+    def __init__(self):
+        self.count = 0
+
+    def tick(self, *args, **kwargs):
+        self.count += 1
+
+
+def make_view():
+    pygame.display.init()
+    clock = DummyClock()
+    with patch('pygame.display.set_mode', return_value=pygame.Surface((1, 1))):
+        with patch('pygame.font.SysFont', return_value=DummyFont()):
+            with patch.object(pygame_gui, 'load_card_images'):
+                with patch('pygame.time.Clock', return_value=clock):
+                    view = pygame_gui.GameView(1, 1)
+    view._draw_frame = lambda: None
+    return view, clock
+
+
 def test_update_hand_sprites():
     pygame.display.init()
     with patch('pygame.display.set_mode', return_value=pygame.Surface((1, 1))):
@@ -21,4 +41,35 @@ def test_update_hand_sprites():
                 view = pygame_gui.GameView(1, 1)
                 view.update_hand_sprites()
                 assert len(view.hand_sprites) == len(view.game.players[0].hand)
+    pygame.quit()
+
+
+def test_animate_sprites_speed():
+    view, clock = make_view()
+    sprite = pygame.sprite.Sprite()
+    sprite.image = pygame.Surface((1, 1))
+    sprite.rect = sprite.image.get_rect()
+    with patch('pygame.event.pump'), patch('pygame.display.flip'):
+        view.animation_speed = 2.0
+        view._animate_sprites([sprite], (0, 0), frames=10)
+        assert clock.count == 5
+    pygame.quit()
+
+
+def test_animate_back_speed():
+    view, clock = make_view()
+    with patch.object(pygame_gui, 'get_card_back', return_value=pygame.Surface((1, 1))):
+        with patch('pygame.event.pump'), patch('pygame.display.flip'):
+            view.animation_speed = 0.5
+            view._animate_back((0, 0), (1, 1), frames=10)
+            assert clock.count == 20
+    pygame.quit()
+
+
+def test_highlight_turn_speed():
+    view, clock = make_view()
+    with patch('pygame.event.pump'), patch('pygame.display.flip'):
+        view.animation_speed = 2.0
+        view._highlight_turn(0, frames=10)
+        assert clock.count == 5
     pygame.quit()


### PR DESCRIPTION
## Summary
- allow changing animation speed in GameView
- apply animation speed to sprite, card back and highlight animations
- expose animation speed options in SettingsOverlay
- test that animations honor the new speed setting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853368e1e94832695babe446ffc8cb7