### PR TITLE
Add GameState enum and integrate into GameView

### DIFF
--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -73,3 +73,25 @@ def test_highlight_turn_speed():
         view._highlight_turn(0, frames=10)
         assert clock.count == 5
     pygame.quit()
+
+
+def test_state_transitions():
+    view, _ = make_view()
+    assert view.state == pygame_gui.GameState.MENU
+    with patch.object(view, 'ai_turns'):
+        view.close_overlay()
+    assert view.state == pygame_gui.GameState.PLAYING
+
+    view.show_settings()
+    assert view.state == pygame_gui.GameState.SETTINGS
+    with patch.object(view, 'ai_turns'):
+        view.handle_key(pygame.K_ESCAPE)
+    assert view.state == pygame_gui.GameState.PLAYING
+
+    view.show_game_over('P1')
+    assert view.state == pygame_gui.GameState.GAME_OVER
+    with patch.object(view, 'ai_turns') as mock:
+        view.handle_key(pygame.K_ESCAPE)
+        mock.assert_not_called()
+    assert view.state == pygame_gui.GameState.GAME_OVER
+    pygame.quit()


### PR DESCRIPTION
## Summary
- create `GameState` enum for Pygame GUI
- track state inside `GameView` and update in overlay methods
- branch on `self.state` in event handlers and run loop
- add tests for new state transitions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685337e59700832697d0f3efb869c9c1