### PR TITLE
Fix sprite selection order

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -394,7 +394,7 @@ class GameView:
                 event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, {'pos': pos})
                 self.overlay.handle_event(event)
             return
-        for sp in self.selected:
+        for sp in reversed(self.selected):
             if sp.rect.collidepoint(pos):
                 up = not sp.selected
                 sp.toggle()
@@ -405,7 +405,7 @@ class GameView:
                 else:
                     self.selected.remove(sp)
                 return
-        for sp in self.hand_sprites:
+        for sp in reversed(self.hand_sprites.sprites()):
             if sp.rect.collidepoint(pos):
                 up = not sp.selected
                 sp.toggle()
@@ -482,7 +482,7 @@ class GameView:
     # Rendering -------------------------------------------------------
     def update_hand_sprites(self):
         player = self.game.players[0]
-        self.hand_sprites = pygame.sprite.Group()
+        self.hand_sprites = pygame.sprite.OrderedUpdates()
         start_x, y = self._player_pos(0)
         card_w = self.card_width
         spacing = min(40, card_w)

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -83,7 +83,7 @@ def test_handle_mouse_select_and_overlay():
     view, _ = make_view()
     sprite = DummySprite()
     center = sprite.rect.center
-    view.hand_sprites = [sprite]
+    view.hand_sprites = pygame.sprite.OrderedUpdates(sprite)
     view.selected = []
     view.state = pygame_gui.GameState.PLAYING
 
@@ -101,6 +101,21 @@ def test_handle_mouse_select_and_overlay():
     view.handle_mouse((5, 5))
     event = overlay.handle_event.call_args[0][0]
     assert event.pos == (5, 5)
+    pygame.quit()
+
+
+def test_handle_mouse_selects_rightmost_sprite():
+    view, _ = make_view()
+    left = DummySprite((5, 5))
+    right = DummySprite((5, 5))
+    view.hand_sprites = pygame.sprite.OrderedUpdates(left, right)
+    view.selected = []
+    view.state = pygame_gui.GameState.PLAYING
+
+    view.handle_mouse((5, 5))
+    assert right.selected is True
+    assert right in view.selected
+    assert left.selected is False
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- ensure hand sprites maintain draw order using `OrderedUpdates`
- iterate sprite lists in reverse when handling mouse input
- update mouse handling tests for `OrderedUpdates`
- add regression test for selecting the topmost overlapping sprite

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534c9542c88326906762309e16a027