### PR TITLE
Add action buttons to pygame GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ are handled automatically.
   layout is implemented yet.
 - Press **Enter** or **Space** for the usual shortcuts.
 - Settings and menu overlays similar to the Tkinter version.
+- On-screen **Play**, **Pass** and **Undo** buttons between your hand and the pile.
 
 Displaying card images requires the **Pillow** library, which is
 included in `requirements.txt`. Install dependencies (including Pillow


### PR DESCRIPTION
## Summary
- add Play/Pass/Undo buttons to `GameView`
- draw and handle new buttons with enabled state for Undo
- reposition buttons on resize and fullscreen toggle
- extend button helper with optional disabled drawing
- document new controls in README
- update Pygame GUI tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534e0a71e883269d67cf1a7023b82e