### PR TITLE
Fix ruff errors and tidy tests

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,7 +1,6 @@
 import tkinter as tk
 from tkinter import messagebox
 from tkinter import font as tkfont
-import time
 from pathlib import Path
 from PIL import Image, ImageTk
 import random

--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -193,7 +193,6 @@ class SettingsOverlay(Overlay):
         by = h // 2 - 220
 
         def cycle(attr: str, options: List, label: str) -> Callable[[], None]:
-            btn: Button
             def callback(b: Button) -> Callable[[], None]:
                 def inner() -> None:
                     cur = getattr(view, attr)

--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import colorchooser
 from tkinter import ttk
 import sound
+import tien_len_full as rules
 try:
     import pygame
 except ImportError:  # pragma: no cover - pygame optional
@@ -11,7 +12,6 @@ except ImportError:  # pragma: no cover - pygame optional
 def _mixer_ready() -> bool:
     """Return True if pygame and the mixer are initialized."""
     return bool(pygame and pygame.mixer.get_init())
-import tien_len_full as rules
 
 class SettingsDialog(tk.Toplevel):
     """Modal dialog for adjusting game options."""

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -1,10 +1,10 @@
 from unittest.mock import MagicMock, patch
 import sys
-
-sys.modules.setdefault('pygame', MagicMock())
-
 import gui
 from tien_len_full import Game, Card
+
+sys.modules.setdefault('pygame', MagicMock())
+gui.pygame = sys.modules['pygame']
 
 
 def make_gui_stub(root):
@@ -68,7 +68,7 @@ def test_show_rules_creates_modal():
     win = MagicMock()
     with patch('gui.tk.Toplevel', return_value=win) as mock_top, \
          patch('gui.tk.Frame') as mock_frame, \
-         patch('gui.tk.Label') as mock_label, \
+         patch('gui.tk.Label'), \
          patch('gui.tk.Button') as mock_button:
         gui_obj.show_rules()
         mock_top.assert_called_with(gui_obj.root)
@@ -85,7 +85,7 @@ def test_show_menu_overlay():
     overlay = MagicMock()
     box = MagicMock()
     with patch('gui.tk.Frame', side_effect=[overlay, box]) as mock_frame, \
-         patch('gui.tk.Label') as mock_label, \
+         patch('gui.tk.Label'), \
          patch('gui.tk.Button') as mock_button:
         gui_obj.show_menu()
         mock_frame.assert_any_call(gui_obj.root, bg='#000000')
@@ -98,7 +98,7 @@ def test_menu_includes_tutorial_button():
     gui_obj = make_gui_stub(root)
     overlay = MagicMock()
     box = MagicMock()
-    with patch('gui.tk.Frame', side_effect=[overlay, box]) as mock_frame, \
+    with patch('gui.tk.Frame', side_effect=[overlay, box]), \
          patch('gui.tk.Label'), \
          patch('gui.tk.Button') as mock_button:
         gui_obj.show_menu()

--- a/tests/test_parse_input.py
+++ b/tests/test_parse_input.py
@@ -1,5 +1,3 @@
-import pytest
-
 from tien_len_full import Game, Card
 
 


### PR DESCRIPTION
## Summary
- clean up unused imports
- move rules import to top of `settings_dialog.py`
- patch Pygame after importing gui in tests
- remove unused variables in tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853ffcea4708326956f2f5b124c4aeb