### PR TITLE
Add optional dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ coverage run -m pytest
 coverage xml
 ```
 
+Tests that exercise the graphical interfaces require the optional
+`Pillow` and `pygame` libraries. Pytest will automatically skip these
+tests when the dependencies are not available.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/tests/test_gui_features.py
+++ b/tests/test_gui_features.py
@@ -1,3 +1,7 @@
+import pytest
+pytest.importorskip("PIL")
+pytest.importorskip("pygame")
+
 from unittest.mock import MagicMock, patch
 import sys
 import gui

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -1,3 +1,7 @@
+import pytest
+pytest.importorskip("PIL")
+pytest.importorskip("pygame")
+
 import os
 from unittest.mock import patch, MagicMock
 


### PR DESCRIPTION
## Summary
- skip GUI tests when Pillow or pygame aren't available
- mention conditional skips in README testing section

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685402003ce88326b9097c5ca0417fd4