### PR TITLE
Add tracemalloc memory usage test

### DIFF
--- a/tests/test_memory_usage.py
+++ b/tests/test_memory_usage.py
@@ -1,0 +1,59 @@
+import os
+import pytest
+pytest.importorskip("pygame")
+
+import tracemalloc
+from unittest.mock import patch
+
+import pygame
+import pygame_gui
+
+# Use dummy video driver so no window is opened
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+
+class DummyFont:
+    def render(self, *args, **kwargs):
+        return pygame.Surface((1, 1))
+
+
+class DummyClock:
+    def tick(self, *args, **kwargs):
+        pass
+
+
+def make_view():
+    pygame.display.init()
+    clock = DummyClock()
+    with patch('pygame.display.set_mode', return_value=pygame.Surface((1, 1))):
+        with patch('pygame.font.SysFont', return_value=DummyFont()):
+            with patch.object(pygame_gui, 'load_card_images'):
+                with patch('pygame.time.Clock', return_value=clock):
+                    with patch.object(pygame_gui.GameView, '_highlight_turn'):
+                        view = pygame_gui.GameView(1, 1)
+    view._draw_frame = lambda: None
+    return view
+
+
+def test_run_memory_usage():
+    view = make_view()
+    frames = 5
+
+    def side_effect():
+        nonlocal frames
+        if frames:
+            frames -= 1
+            return []
+        return [pygame.event.Event(pygame.QUIT, {})]
+
+    with patch('pygame.event.get', side_effect=side_effect), patch('pygame.quit'):
+        tracemalloc.start()
+        before = tracemalloc.take_snapshot()
+        view.run()
+        after = tracemalloc.take_snapshot()
+        tracemalloc.stop()
+
+    diff = after.compare_to(before, 'filename')
+    total = sum(stat.size_diff for stat in diff)
+    assert abs(total) < 50_000
+    pygame.quit()


### PR DESCRIPTION
## Summary
- add `tests/test_memory_usage.py`
- use `tracemalloc` to verify `GameView.run` doesn't leak memory over a few frames

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685424dd54408326b2209c2cf8c10a33