### PR TITLE
Fix file logger encoding

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -17,7 +17,7 @@ LOG_FILE = "tien_len_game.log"
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:
-    handler = logging.FileHandler(LOG_FILE)
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -32,7 +32,7 @@ LOG_FILE = 'tien_len_game.log'
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:
-    handler = logging.FileHandler(LOG_FILE)
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
     formatter = logging.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     )


### PR DESCRIPTION
## Summary
- avoid UnicodeEncodeError on Windows by writing log files in UTF-8

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685438429ae08326964beff6b1e982d8