### PR TITLE
Enhance round summary logging

### DIFF
--- a/tests/test_round_summary.py
+++ b/tests/test_round_summary.py
@@ -1,0 +1,28 @@
+import logging
+from tien_len_full import Game, Card, logger
+
+
+def test_summary_round_logs_winner_and_next_starter(caplog):
+    game = Game()
+    winner = game.players[1]
+    loser = game.players[0]
+
+    game.pile = [
+        (loser, [Card('Spades', '3')]),
+        (winner, [Card('Hearts', '4')]),
+    ]
+    # Give players some hands for display_overview
+    loser.hand = [Card('Clubs', '5')]
+    winner.hand = []
+    game.players[2].hand = [Card('Diamonds', '6')]
+    game.players[3].hand = [Card('Clubs', '7')]
+
+    with caplog.at_level(logging.INFO):
+        logger.addHandler(caplog.handler)
+        game.summary_round()
+        logger.removeHandler(caplog.handler)
+
+    messages = [rec.message for rec in caplog.records]
+    assert any(f"{winner.name} won the round" in m for m in messages)
+    assert any(f"{winner.name} will start the next round" in m for m in messages)
+

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -541,6 +541,15 @@ class Game:
         logger.info('\n-- Round Summary --')
         for p, c in self.pile:
             logger.info(" %s: %s", p.name, c)
+
+        # Determine who played the last non-pass move
+        winner = None
+        combo = None
+        if self.pile:
+            winner, combo = self.pile[-1]
+            logger.info("%s won the round with %s", winner.name, combo)
+            logger.info("%s will start the next round", winner.name)
+
         self.display_overview()
         logger.info('--')
         log_action(f"Round summary: {self.pile}")


### PR DESCRIPTION
## Summary
- show the winner at the end of each round
- mention who starts next round
- test the new log output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544c7776f08326a5afaba44a929620