### PR TITLE
Use predefined names for AI opponents

### DIFF
--- a/tests/test_json_serialization.py
+++ b/tests/test_json_serialization.py
@@ -1,10 +1,12 @@
 import json
 import pytest
-from tien_len_full import Game, Card
+from unittest.mock import patch
+from tien_len_full import Game, Card, AI_NAMES
 
 
 def setup_game_state():
-    game = Game()
+    with patch('random.sample', return_value=AI_NAMES[:3]):
+        game = Game()
     # Simple deterministic state
     game.players[0].hand = [Card('Spades', '3')]
     game.players[1].hand = [Card('Hearts', '4')]
@@ -16,7 +18,7 @@ def setup_game_state():
     game.start_idx = 0
     game.first_turn = False
     game.pass_count = 1
-    game.history = [(1, 'AI 1 plays 5♦')]
+    game.history = [(1, f'{AI_NAMES[0]} plays 5♦')]
     game.current_round = 2
     game.scores = {p.name: i for i, p in enumerate(game.players)}
     return game
@@ -31,14 +33,16 @@ def test_to_json_from_json_round_trip():
     assert data['current_idx'] == 1
     assert data['players'][0]['hand'][0] == {'suit': 'Spades', 'rank': '3'}
 
-    restored = Game()
+    with patch('random.sample', return_value=AI_NAMES[:3]):
+        restored = Game()
     restored.from_json(json_data)
 
     assert json.loads(restored.to_json()) == data
 
 
 def test_process_play_round_trip_via_undo():
-    game = Game()
+    with patch('random.sample', return_value=AI_NAMES[:3]):
+        game = Game()
     player = game.players[0]
     player.hand = [Card('Spades', '3')]
     game.current_idx = 0
@@ -57,7 +61,8 @@ def test_process_play_round_trip_via_undo():
 
 
 def test_handle_pass_and_undo_restores_state():
-    game = Game()
+    with patch('random.sample', return_value=AI_NAMES[:3]):
+        game = Game()
     game.players[0].hand = [Card('Spades', '3')]
     game.players[1].hand = [Card('Hearts', '4')]
     game.current_idx = 0

--- a/tests/test_simulated_game.py
+++ b/tests/test_simulated_game.py
@@ -2,16 +2,17 @@ import itertools
 import random
 from unittest.mock import patch
 
-from tien_len_full import Game
+from tien_len_full import Game, AI_NAMES
 
 
 def test_simulated_game():
     # Seed random module so deck shuffling is deterministic
     random.seed(1)
-    game = Game()
+    with patch('random.sample', return_value=AI_NAMES[:3]):
+        game = Game()
     # Provide endless 'pass' inputs for the human player
     inputs = itertools.repeat('pass')
     with patch('builtins.input', lambda *args: next(inputs)):
         game.play()
     winners = [p.name for p in game.players if not p.hand]
-    assert winners == ['AI 2']
+    assert winners == [AI_NAMES[1]]

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -63,6 +63,10 @@ ALLOW_2_IN_SEQUENCE = False
 # values are better.
 TYPE_PRIORITY = {'bomb': 5, 'sequence': 4, 'triple': 3, 'pair': 2, 'single': 1}
 
+# Names used for AI opponents.  The list length exceeds the number of AI
+# players so ``random.sample`` can pick distinct names for each game.
+AI_NAMES = ["Linh", "Phong", "Bao", "Trang", "My", "Tuan", "Nam", "Duy", "Ha", "Minh"]
+
 class Card:
     """Simple container for a playing card."""
 
@@ -205,8 +209,10 @@ class Game:
     def __init__(self) -> None:
         """Initialise a new game instance."""
 
-        # Create one human player followed by three AI opponents.
-        self.players = [Player('Player', True)] + [Player(f'AI {i+1}') for i in range(3)]
+        # Create one human player followed by three AI opponents chosen from a
+        # predefined pool of names.
+        used = random.sample(AI_NAMES, 3)
+        self.players = [Player('Player', True)] + [Player(n) for n in used]
         self.deck = Deck()
         self.pile: list[tuple[Player, list[Card]]] = []
         self.current_idx = 0


### PR DESCRIPTION
## Summary
- add `AI_NAMES` constant with a list of Vietnamese names
- create AI players using a random sample from that list
- patch `random.sample` in tests for deterministic player names

## Testing
- `pytest tests/test_simulated_game.py::test_simulated_game -q`
- `pytest tests/test_json_serialization.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854559dd710832693b79de4bbce0218