### PR TITLE
Add card shadow drawing

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -130,6 +130,17 @@ class CardSprite(pygame.sprite.Sprite):
         offset = -10 if self.selected else 10
         self.rect.move_ip(0, offset)
 
+    def draw_shadow(self, surface: pygame.Surface, offset: Tuple[int, int] = (5, 5),
+                     blur: int = 2, alpha: int = 80) -> None:
+        """Draw a simple blurred shadow beneath the card."""
+        shadow = pygame.Surface(self.image.get_size(), pygame.SRCALPHA)
+        shadow.fill((0, 0, 0))
+        shadow.set_alpha(alpha)
+        for dx in range(-blur, blur + 1):
+            for dy in range(-blur, blur + 1):
+                rect = self.rect.move(offset[0] + dx, offset[1] + dy)
+                surface.blit(shadow, rect)
+
 
 class CardBackSprite(pygame.sprite.Sprite):
     def __init__(self, pos: Tuple[int, int], width: int = 80, name: str = "card_back") -> None:
@@ -905,6 +916,14 @@ class GameView:
             else:
                 rect = img.get_rect(midright=(x - spacing, y))
             self.screen.blit(img, rect)
+
+        for sp in self.hand_sprites.sprites():
+            if isinstance(sp, CardSprite):
+                sp.draw_shadow(self.screen)
+        for group in self.ai_sprites:
+            for sp in group.sprites():
+                if isinstance(sp, CardSprite):
+                    sp.draw_shadow(self.screen)
 
         self.hand_sprites.draw(self.screen)
         for group in self.ai_sprites:

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -171,6 +171,33 @@ def test_update_hand_sprites_calls_update_play_button_state():
         upd.assert_called_once()
 
 
+def test_card_sprite_draw_shadow_blits():
+    pygame.display.init()
+    with patch('pygame.font.SysFont', return_value=DummyFont()):
+        with patch.object(pygame_gui, 'get_card_image',
+                          return_value=pygame.Surface((1, 1), pygame.SRCALPHA)):
+            sprite = pygame_gui.CardSprite(tien_len_full.Card('Spades', '3'),
+                                          (0, 0), 1)
+    surf = MagicMock()
+    sprite.draw_shadow(surf)
+    assert surf.blit.call_count > 0
+    pygame.quit()
+
+
+def test_draw_players_uses_draw_shadow():
+    view, _ = make_view()
+    with patch('pygame.font.SysFont', return_value=DummyFont()):
+        with patch.object(pygame_gui, 'get_card_image',
+                          return_value=pygame.Surface((1, 1), pygame.SRCALPHA)):
+            sprite = pygame_gui.CardSprite(tien_len_full.Card('Spades', '3'),
+                                          (0, 0), 1)
+    view.hand_sprites = pygame.sprite.OrderedUpdates(sprite)
+    with patch.object(sprite, 'draw_shadow') as ds:
+        view.draw_players()
+        ds.assert_called()
+    pygame.quit()
+
+
 def test_animate_sprites_moves_to_destination():
     view, clock = make_view()
     sprite = DummySprite()


### PR DESCRIPTION
## Summary
- extend `CardSprite` with `draw_shadow` helper
- draw shadows for cards before rendering
- test the new shadow drawing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545f9447708326a848505178e3012a