### PR TITLE
Add selection outline to draw_players

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -954,6 +954,13 @@ class GameView:
         self.hand_sprites.draw(self.screen)
         for group in self.ai_sprites:
             group.draw(self.screen)
+        if self.selected:
+            player = self.game.players[self.game.current_idx]
+            cards = [sp.card for sp in self.selected if hasattr(sp, 'card')]
+            valid = self.game.is_valid(player, cards, self.game.current_combo)[0]
+            color = (0, 255, 0) if valid else (255, 0, 0)
+            for sp in self.selected:
+                pygame.draw.rect(self.screen, color, sp.rect, width=3)
         if not self.game.pile:
             self.current_trick.clear()
         if self.current_trick:


### PR DESCRIPTION
## Summary
- draw green/reds outlines around selected cards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854626c69848326ac81da6ed3441703