### PR TITLE
Add sound enabled helper

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -751,7 +751,7 @@ class GameView:
         import tien_len_full as tl
         tl.ALLOW_2_IN_SEQUENCE = not self.house_rules
         sound.set_volume(self.volume)
-        sound._ENABLED = self.sound_enabled
+        sound.set_enabled(self.sound_enabled)
         if _mixer_ready():
             pygame.mixer.music.set_volume(self.volume)
             if self.music_enabled:

--- a/sound.py
+++ b/sound.py
@@ -61,3 +61,9 @@ def set_volume(vol: float) -> None:
             snd.set_volume(_VOLUME)
         except Exception:
             pass
+
+
+def set_enabled(flag: bool) -> None:
+    """Enable or disable all sound effects."""
+    global _ENABLED
+    _ENABLED = bool(flag)

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -15,7 +15,7 @@ def test_load_success(tmp_path):
     mock_instance = MagicMock()
     with patch.object(sound, "pygame", _stub_pygame(MagicMock(return_value=mock_instance))):
         with patch("sound.Path.is_file", return_value=True):
-            sound._ENABLED = True
+            sound.set_enabled(True)
             sound._SOUNDS.clear()
             assert sound.load("hit", wav)
             assert sound._SOUNDS["hit"] is mock_instance
@@ -28,7 +28,7 @@ def test_load_disabled_or_missing(tmp_path):
     # Disabled
     with patch.object(sound, "pygame", _stub_pygame(mock_cls)):
         with patch("sound.Path.is_file", return_value=True):
-            sound._ENABLED = False
+            sound.set_enabled(False)
             sound._SOUNDS.clear()
             assert not sound.load("foo", wav)
             mock_cls.assert_not_called()
@@ -36,7 +36,7 @@ def test_load_disabled_or_missing(tmp_path):
     # Missing file
     with patch.object(sound, "pygame", _stub_pygame(mock_cls)):
         with patch("sound.Path.is_file", return_value=False):
-            sound._ENABLED = True
+            sound.set_enabled(True)
             sound._SOUNDS.clear()
             assert not sound.load("bar", wav)
             mock_cls.assert_not_called()
@@ -49,12 +49,12 @@ def test_play_noop_when_disabled_or_unknown():
     sound._SOUNDS["shoot"] = mock_sound
 
     # Disabled
-    sound._ENABLED = False
+    sound.set_enabled(False)
     sound.play("shoot")
     mock_sound.play.assert_not_called()
 
     # Unknown name
-    sound._ENABLED = True
+    sound.set_enabled(True)
     mock_sound.play.reset_mock()
     sound.play("missing")
     mock_sound.play.assert_not_called()
@@ -65,6 +65,6 @@ def test_play_handles_errors():
     mock_sound.play.side_effect = Exception("boom")
     sound._SOUNDS.clear()
     sound._SOUNDS["explode"] = mock_sound
-    sound._ENABLED = True
+    sound.set_enabled(True)
     sound.play("explode")  # should not raise
     mock_sound.play.assert_called_once()


### PR DESCRIPTION
## Summary
- add `sound.set_enabled` helper
- call the helper from `pygame_gui.apply_options`
- adjust unit tests to use the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859590d4c58832691f667639f2ef40d