### PR TITLE
Refactor menu overlays

### DIFF
--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -512,7 +512,7 @@ def test_on_resize_repositions_layout():
 def test_overlay_instances_created():
     view, _ = make_view()
     view.show_menu()
-    assert isinstance(view.overlay, pygame_gui.MenuOverlay)
+    assert isinstance(view.overlay, pygame_gui.MainMenuOverlay)
     view.show_settings()
     assert isinstance(view.overlay, pygame_gui.SettingsOverlay)
     view.show_game_over('P1')


### PR DESCRIPTION
## Summary
- implement new overlay hierarchy with MainMenuOverlay and SettingsOverlay
- add GameSettingsOverlay, GraphicsOverlay, AudioOverlay and RulesOverlay
- update `GameView` to use new overlay classes
- adjust tests for new overlay names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c798d73048326a2a2b0d18a1bc0d7