### PR TITLE
Add overlay transition animation

### DIFF
--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -555,6 +555,14 @@ def test_overlay_instances_created():
     assert view.overlay is None
 
 
+def test_overlay_transitions_called():
+    view, _ = make_view()
+    with patch.object(view, "_transition_overlay") as trans:
+        view.show_settings()
+        view.show_menu()
+    assert trans.call_count == 2
+
+
 def test_draw_frame_with_overlay():
     view, _ = make_view()
     # restore original method


### PR DESCRIPTION
## Summary
- implement `_transition_overlay` for fade/slide animations
- add `_activate_overlay` helper and use it in overlay switching methods
- test that overlay transitions are invoked when switching overlays

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c823052d883268311beaba55b02f1