### PR TITLE
Add House Rules options to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ are handled automatically.
 - Sprites and layout adapt automatically when the window is resized.
 - Press **Enter** or **Space** for the usual shortcuts.
 - Settings and menu overlays are provided.
+- A dedicated *House Rules* screen lets you toggle optional rules
+  such as “Chặt” bombs, chain cutting and others.
 - On-screen **Play**, **Pass** and **Undo** buttons between your hand and the pile.
 
 Displaying card images requires the **Pillow** library, which is

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -554,6 +554,8 @@ def test_overlay_instances_created():
     assert isinstance(view.overlay, pygame_gui.GraphicsOverlay)
     view.show_audio()
     assert isinstance(view.overlay, pygame_gui.AudioOverlay)
+    view.show_rules()
+    assert isinstance(view.overlay, pygame_gui.RulesOverlay)
     view.show_how_to_play()
     assert isinstance(view.overlay, pygame_gui.HowToPlayOverlay)
     view.show_tutorial()
@@ -654,6 +656,7 @@ def test_restart_game_preserves_scores():
         (pygame_gui.GameSettingsOverlay, ()),
         (pygame_gui.GraphicsOverlay, ()),
         (pygame_gui.AudioOverlay, ()),
+        (pygame_gui.RulesOverlay, (lambda: None,)),
         (pygame_gui.HowToPlayOverlay, (lambda: None,)),
         (pygame_gui.TutorialOverlay, (lambda: None,)),
     ],
@@ -768,6 +771,11 @@ def test_options_persist_across_sessions(tmp_path):
         view.colorblind_mode = True
         view.fx_volume = 0.5
         view.music_volume = 0.25
+        view.rule_chat_bomb = True
+        view.rule_chain_cutting = True
+        view.rule_tu_quy_hierarchy = True
+        view.rule_flip_suit_rank = True
+        view.rule_no_2s = False
         view._save_options()
         # create new view that loads from same options file
         new_view, _ = make_view()
@@ -775,3 +783,26 @@ def test_options_persist_across_sessions(tmp_path):
     assert new_view.colorblind_mode is True
     assert new_view.fx_volume == 0.5
     assert new_view.music_volume == 0.25
+    assert new_view.rule_chat_bomb is True
+    assert new_view.rule_chain_cutting is True
+    assert new_view.rule_tu_quy_hierarchy is True
+    assert new_view.rule_flip_suit_rank is True
+    assert new_view.rule_no_2s is False
+
+
+def test_rules_overlay_toggles_update_state():
+    view, _ = make_view()
+    view.show_rules()
+    overlay = view.overlay
+    attrs = [
+        "rule_chat_bomb",
+        "rule_chain_cutting",
+        "rule_tu_quy_hierarchy",
+        "rule_flip_suit_rank",
+        "rule_no_2s",
+    ]
+    for btn, attr in zip(overlay.buttons[:-1], attrs):
+        start = getattr(view, attr)
+        btn.callback()
+        assert getattr(view, attr) != start
+    pygame.quit()

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -58,6 +58,12 @@ RANKS = ['3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A', '2']
 # The default preserves the house rule used by the tests which forbids 2s
 # in sequences.
 ALLOW_2_IN_SEQUENCE = False
+# Additional optional rules toggles.  These defaults match the behaviour
+# used by the tests and GUI unless overridden.
+CHAT_BOMB = False
+CHAIN_CUTTING = False
+TU_QUY_HIERARCHY = False
+FLIP_SUIT_RANK = False
 
 # Rough ranking used by the very simple AI to choose which move to play.  Higher
 # values are better.


### PR DESCRIPTION
## Summary
- expand `tien_len_full` with optional rule flags
- implement `RulesOverlay` with rule toggles
- load/save rule options and apply them in `GameView`
- add 'House Rules' button under game settings
- document the new overlay
- test overlay interaction and persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8876780083268d111d7b972a8141