### PR TITLE
Move scoreboard to top-left

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -1510,11 +1510,6 @@ class GameView:
 
     def draw_score_overlay(self) -> None:
         """Render a scoreboard panel with last hands played."""
-        size = self.screen.get_size()
-        if isinstance(size, (list, tuple)) and len(size) >= 2:
-            w = size[0]
-        else:
-            w = 0
         line_height = getattr(self.font, "get_linesize", lambda: 20)()
         lines = [
             f"{p.name}: {len(p.hand)} ({self.win_counts.get(p.name, 0)})"
@@ -1535,7 +1530,7 @@ class GameView:
             img = self.font.render(line, True, (255, 255, 255))
             panel.blit(img, (5, y))
             y += line_height
-        rect = panel.get_rect(topright=(w - 10, 10))
+        rect = panel.get_rect(topleft=(10, 10))
         self.screen.blit(panel, rect.topleft)
 
     def run(self):

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -621,7 +621,7 @@ def test_draw_score_overlay_positions_panel():
     surf = pygame.Surface((200, 20))
     with patch("pygame.Surface", return_value=surf):
         view.draw_score_overlay()
-    view.screen.blit.assert_called_with(surf, (300 - 200 - 10, 10))
+    view.screen.blit.assert_called_with(surf, (10, 10))
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- draw_score_overlay no longer relies on screen width
- position score overlay panel at (10, 10)
- update test for the new scoreboard position

## Testing
- `pytest -k draw_score_overlay_positions_panel -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd78d133083269ef4d29b8ad0a634