### PR TITLE
Add Save Game button to main menu overlay

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -311,6 +311,49 @@ class MainMenuOverlay(Overlay):
             self.focus_idx = max(0, len(self.buttons) - 1)
 
 
+class InGameMenuOverlay(Overlay):
+    """Menu accessible during gameplay via the Settings button."""
+
+    def __init__(self, view: "GameView") -> None:
+        super().__init__(view, view.close_overlay)
+        self._layout()
+
+    def resize(self) -> None:
+        self._layout()
+
+    def _layout(self) -> None:
+        w, h = self.view.screen.get_size()
+        font = self.view.font
+        bx = w // 2 - 100
+        by = h // 2 - 120
+        self.buttons = [
+            Button("Save Game", pygame.Rect(bx, by, 200, 40), self.view.save_game, font),
+            Button(
+                "Load Game",
+                pygame.Rect(bx, by + 50, 200, 40),
+                self.view.load_game,
+                font,
+            ),
+            Button(
+                "Game Settings",
+                pygame.Rect(bx, by + 100, 200, 40),
+                self.view.show_settings,
+                font,
+            ),
+            Button(
+                "Return to Main Menu",
+                pygame.Rect(bx, by + 150, 200, 40),
+                self.view.show_menu,
+                font,
+            ),
+            Button(
+                "Quit Game", pygame.Rect(bx, by + 200, 200, 40), self.view.quit_game, font
+            ),
+        ]
+        if self.focus_idx >= len(self.buttons):
+            self.focus_idx = max(0, len(self.buttons) - 1)
+
+
 class SettingsOverlay(Overlay):
     """Top level settings menu."""
 
@@ -1079,8 +1122,10 @@ class GameView:
         font = self.font
         if not hasattr(self, "settings_button"):
             self.settings_button = Button(
-                "Settings", pygame.Rect(0, 0, 100, 40), self.show_settings, font
+                "Settings", pygame.Rect(0, 0, 100, 40), self.show_in_game_menu, font
             )
+        else:
+            self.settings_button.callback = self.show_in_game_menu
         margin = max(5, self.card_width // 3)
         self.settings_button.rect.topright = (w - margin, margin)
 
@@ -1095,6 +1140,9 @@ class GameView:
     # Overlay helpers -------------------------------------------------
     def show_menu(self) -> None:
         self._activate_overlay(MainMenuOverlay(self), GameState.MENU)
+
+    def show_in_game_menu(self) -> None:
+        self._activate_overlay(InGameMenuOverlay(self), GameState.SETTINGS)
 
     def show_settings(self) -> None:
         self._activate_overlay(SettingsOverlay(self), GameState.SETTINGS)

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -273,6 +273,8 @@ def test_state_methods_update_state():
         with patch.object(view, "ai_turns"):
             view.close_overlay()
         assert view.state == pygame_gui.GameState.PLAYING
+        view.show_in_game_menu()
+        assert view.state == pygame_gui.GameState.SETTINGS
         view.show_settings()
         assert view.state == pygame_gui.GameState.SETTINGS
         view.show_menu()
@@ -548,6 +550,8 @@ def test_overlay_instances_created():
     with patch("pygame.display.flip"), patch("pygame.event.pump"):
         view.show_menu()
         assert isinstance(view.overlay, pygame_gui.MainMenuOverlay)
+        view.show_in_game_menu()
+        assert isinstance(view.overlay, pygame_gui.InGameMenuOverlay)
         view.show_settings()
         assert isinstance(view.overlay, pygame_gui.SettingsOverlay)
         view.show_game_settings()
@@ -654,6 +658,7 @@ def test_restart_game_preserves_scores():
     "cls, args",
     [
         (pygame_gui.MainMenuOverlay, ()),
+        (pygame_gui.InGameMenuOverlay, ()),
         (pygame_gui.SettingsOverlay, ()),
         (pygame_gui.GameSettingsOverlay, ()),
         (pygame_gui.GraphicsOverlay, ()),
@@ -702,6 +707,40 @@ def test_main_menu_has_save_button():
     pygame.quit()
 
 
+def test_in_game_menu_buttons():
+    view, _ = make_view()
+    overlay = pygame_gui.InGameMenuOverlay(view)
+    texts = [b.text for b in overlay.buttons]
+    cbs = [b.callback for b in overlay.buttons]
+    assert texts == [
+        "Save Game",
+        "Load Game",
+        "Game Settings",
+        "Return to Main Menu",
+        "Quit Game",
+    ]
+    assert cbs == [
+        view.save_game,
+        view.load_game,
+        view.show_settings,
+        view.show_menu,
+        view.quit_game,
+    ]
+    pygame.quit()
+
+
+def test_settings_button_opens_in_game_menu():
+    view, _ = make_view()
+    with patch.object(view, "_save_options"), patch.object(view, "ai_turns"), patch(
+        "pygame.display.flip"
+    ):
+        view.close_overlay()
+    view.settings_button.callback = MagicMock()
+    view.handle_mouse(view.settings_button.rect.center)
+    view.settings_button.callback.assert_called_once()
+    pygame.quit()
+
+
 def test_how_to_play_overlay_escape_returns_menu():
     view, _ = make_view()
     with patch.object(view, "show_menu") as show_menu, patch("pygame.display.flip"):
@@ -743,6 +782,7 @@ def test_on_resize_calls_overlay_resize():
     "show_fn, args",
     [
         ("show_menu", ()),
+        ("show_in_game_menu", ()),
         ("show_settings", ()),
         ("show_game_settings", ()),
         ("show_graphics", ()),


### PR DESCRIPTION
## Summary
- include a Save Game option in MainMenuOverlay
- keep focus index valid when layout changes
- test that the menu exposes a Save Game button calling GameView.save_game

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dec53e69083269524c87aee9e5325