### PR TITLE
Fix straight detection

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -38,11 +38,14 @@ def test_combo_detection():
     assert is_bomb(bomb)
     assert detect_combo(bomb) == 'bomb'
 
-    seq = make_cards(('Spades', '3'), ('Spades', '4'), ('Spades', '5'))
+    seq = make_cards(('Spades', '3'), ('Hearts', '4'), ('Clubs', '5'))
     assert is_sequence(seq)
     assert detect_combo(seq) == 'sequence'
 
-    bad_seq = make_cards(('Spades', '3'), ('Spades', '4'), ('Spades', '2'))
+    suited_seq = make_cards(('Spades', '7'), ('Spades', '8'), ('Spades', '9'))
+    assert is_sequence(suited_seq)
+
+    bad_seq = make_cards(('Spades', '3'), ('Hearts', '3'), ('Clubs', '4'))
     assert not is_sequence(bad_seq)
 
 

--- a/tests/test_simulated_game.py
+++ b/tests/test_simulated_game.py
@@ -15,4 +15,4 @@ def test_simulated_game():
     with patch('builtins.input', lambda *args: next(inputs)):
         game.play()
     winners = [p.name for p in game.players if not p.hand]
-    assert winners == [AI_NAMES[1]]
+    assert winners == [AI_NAMES[0]]

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -159,17 +159,17 @@ def is_bomb(cards) -> bool:
     return len(cards) == 4 and len({c.rank for c in cards}) == 1
 
 def is_sequence(cards) -> bool:
-    """Return ``True`` if the cards form a suited consecutive sequence."""
+    """Return ``True`` if ``cards`` form a valid straight."""
 
     if len(cards) < 3:
         return False
     # Optionally disallow sequences containing a 2
     if not ALLOW_2_IN_SEQUENCE and any(c.rank == '2' for c in cards):
         return False
-    # All cards must share the same suit
-    if len({c.suit for c in cards}) != 1:
-        return False
     idx = sorted(RANKS.index(c.rank) for c in cards)
+    # Ranks must be unique and consecutive
+    if len(set(idx)) != len(idx):
+        return False
     return all(idx[i] + 1 == idx[i + 1] for i in range(len(idx) - 1))
 
 def detect_combo(cards):


### PR DESCRIPTION
## Summary
- allow mixed-suit sequences
- add tests for new rule
- update deterministic game outcome

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e03f365a48326b6c91c8775ee6653