### PR TITLE
Update current trick layout

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -1171,7 +1171,8 @@ class GameView:
         w, h = self.screen.get_size()
         if self.action_buttons:
             top = self.action_buttons[0].rect.top
-            y = top - self.card_width
+            card_h = int(self.card_width * 1.4)
+            y = top - card_h
         else:
             y = h // 2
         return w // 2, y
@@ -1725,17 +1726,17 @@ class GameView:
         if not self.game.pile:
             self.current_trick.clear()
         if self.current_trick:
-            center = self._pile_center()
-            radius = self.card_width * 1.5
-            total = len(self.current_trick)
+            center_x, y = self._pile_center()
+            card_w = self.card_width
+            spacing = max(5, card_w - 25)
+            total_w = card_w + (len(self.current_trick) - 1) * spacing
+            start = center_x - total_w // 2 + card_w // 2
             for i, (name, img) in enumerate(self.current_trick):
-                angle = math.tau * i / total - math.pi / 2
-                x = center[0] + radius * math.cos(angle)
-                y = center[1] + radius * math.sin(angle)
+                x = start + i * spacing
                 rect = img.get_rect(center=(int(x), int(y)))
                 self.screen.blit(img, rect)
                 label = self.font.render(name, True, (255, 255, 255))
-                lrect = label.get_rect(center=(int(x), int(y - self.card_width)))
+                lrect = label.get_rect(midbottom=(rect.centerx, rect.top))
                 self.screen.blit(label, lrect)
 
         if self.state == GameState.PLAYING:

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -671,6 +671,29 @@ def test_current_trick_reset_on_restart_and_new_round():
     pygame.quit()
 
 
+def test_draw_players_displays_trick_linearly():
+    view, _ = make_view()
+    view.hand_sprites = pygame.sprite.OrderedUpdates()
+    view.ai_sprites = []
+    surf1 = pygame.Surface((10, 20))
+    surf2 = pygame.Surface((10, 20))
+    view.current_trick = [("A", surf1), ("B", surf2)]
+    view.screen = MagicMock()
+    view.screen.get_size.return_value = (200, 200)
+    with patch.object(view, "_pile_center", return_value=(100, 50)):
+        view.draw_players()
+    calls = [c for c in view.screen.blit.call_args_list if c.args[0] in (surf1, surf2)]
+    card_w = view.card_width
+    spacing = max(5, card_w - 25)
+    total_w = card_w + spacing
+    start = 100 - total_w // 2 + card_w // 2
+    expected = {surf1: (start, 50), surf2: (start + spacing, 50)}
+    for call in calls:
+        surf, rect = call.args
+        assert rect.center == expected[surf]
+    pygame.quit()
+
+
 @pytest.mark.parametrize(
     "cls, args",
     [


### PR DESCRIPTION
## Summary
- adjust `_pile_center` to reserve a taller slot for the pile
- render the current trick in a horizontal row above the action buttons
- test the new layout logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615345258083268ca62d8b148c58e0