### PR TITLE
Compute button positions from pile center

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -1172,12 +1172,10 @@ class GameView:
 
     def _pile_center(self) -> Tuple[int, int]:
         w, h = self.screen.get_size()
-        if self.action_buttons:
-            top = self.action_buttons[0].rect.top
-            card_h = int(self.card_width * 1.4)
-            y = top - card_h
-        else:
-            y = h // 2
+        card_h = int(self.card_width * 1.4)
+        spacing = max(10, self.card_width // 2)
+        _, hand_y = self._player_pos(0)
+        y = hand_y + spacing - card_h // 2
         return w // 2, y
 
     def _calc_card_width(self, win_width: int) -> int:
@@ -1206,16 +1204,14 @@ class GameView:
         total = btn_w * 3 + spacing * 2
         start_x = w // 2 - total // 2
 
-        # Position buttons relative to the player's hand
-        _, hand_y = self._player_pos(0)
+        # Position buttons relative to the pile location
+        _, pile_y = self._pile_center()
         sprites = getattr(self, "hand_sprites", None)
         if sprites:
             card_h = sprites.sprites()[0].rect.height
         else:
             card_h = int(self.card_width * 1.4)
-        hand_bottom_y = hand_y + card_h // 2
-        control_spacing = spacing
-        y = hand_bottom_y + control_spacing
+        y = pile_y + card_h
 
         font = self.font
         self.action_buttons = [

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -521,13 +521,15 @@ def test_on_resize_repositions_layout():
             ):
                 view = pygame_gui.GameView(300, 200)
                 pos_small = view._player_pos(0)
-                btn_small = [b.rect.x for b in view.action_buttons]
+                btn_small_x = [b.rect.x for b in view.action_buttons]
+                btn_small_y = [b.rect.y for b in view.action_buttons]
                 settings_small = view.settings_button.rect.topright
 
                 view.on_resize(600, 400)
 
                 pos_large = view._player_pos(0)
-                btn_large = [b.rect.x for b in view.action_buttons]
+                btn_large_x = [b.rect.x for b in view.action_buttons]
+                btn_large_y = [b.rect.y for b in view.action_buttons]
                 settings_large = view.settings_button.rect.topright
 
                 card_w = view.card_width
@@ -537,15 +539,18 @@ def test_on_resize_repositions_layout():
                 spacing = max(10, card_w // 2)
                 total = 120 * 3 + spacing * 2
                 start_x = 600 // 2 - total // 2
+                expected_y = view._pile_center()[1] + card_h
                 setting_margin = min(60, max(40, card_w // 3))
                 expected_settings = (600 - setting_margin, setting_margin)
 
     pygame.quit()
     assert pos_large == expected_pos
-    assert btn_large[0] == start_x
+    assert btn_large_x[0] == start_x
+    assert btn_large_y[0] == expected_y
     assert settings_large == expected_settings
     assert pos_small != pos_large
-    assert btn_small[0] != btn_large[0]
+    assert btn_small_x[0] != btn_large_x[0]
+    assert btn_small_y[0] != btn_large_y[0]
     assert settings_small != settings_large
 
 


### PR DESCRIPTION
## Summary
- derive action button coordinates from `_pile_center`
- make `_pile_center` independent from action button layout
- verify button Y position when resizing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861575319d88326af8a73157199cfa8