### PR TITLE
Implement label padding for player names

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -45,6 +45,8 @@ OPTIONS_FILE = Path(__file__).with_name("options.json")
 
 # Default distance between cards in a player's hand
 HAND_SPACING = 30
+# Extra padding used when positioning player labels
+LABEL_PAD = 10
 
 
 # ---------------------------------------------------------------------------
@@ -1700,16 +1702,16 @@ class GameView:
             color = (255, 255, 0) if idx == self.game.current_idx else (255, 255, 255)
             img = self.font.render(txt, True, color)
             if idx == 0:
-                offset = card_h // 2 + spacing // 2
+                offset = card_h // 2 + spacing // 2 + LABEL_PAD
                 rect = img.get_rect(midbottom=(x, y - offset))
             elif idx == 1:
-                offset = card_h // 2 + spacing // 2
+                offset = card_h // 2 + spacing // 2 + LABEL_PAD
                 rect = img.get_rect(midtop=(x, y + offset))
             elif idx == 2:
-                offset = card_w // 2 + spacing // 2
+                offset = card_w // 2 + spacing // 2 + LABEL_PAD
                 rect = img.get_rect(midleft=(x + offset, y))
             else:
-                offset = card_w // 2 + spacing // 2
+                offset = card_w // 2 + spacing // 2 + LABEL_PAD
                 rect = img.get_rect(midright=(x - offset, y))
             self.screen.blit(img, rect)
 

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -210,6 +210,41 @@ def test_draw_players_uses_draw_shadow():
     pygame.quit()
 
 
+def test_draw_players_labels_use_padding():
+    view, _ = make_view()
+    view.hand_sprites = pygame.sprite.OrderedUpdates()
+    view.ai_sprites = []
+    view.screen = MagicMock()
+    view.screen.get_size.return_value = (200, 200)
+
+    positions = {
+        0: (100, 150),
+        1: (100, 50),
+        2: (50, 100),
+        3: (150, 100),
+    }
+
+    def player_pos(idx):
+        return positions[idx]
+
+    with patch.object(view, "_player_pos", side_effect=player_pos):
+        view.draw_players()
+
+    calls = view.screen.blit.call_args_list
+    assert len(calls) == 4
+
+    card_w = view.card_width
+    card_h = int(card_w * 1.4)
+    spacing = min(40, card_w)
+    pad_v = card_h // 2 + spacing // 2 + pygame_gui.LABEL_PAD
+    pad_h = card_w // 2 + spacing // 2 + pygame_gui.LABEL_PAD
+
+    assert calls[0].args[1].midbottom == (100, 150 - pad_v)
+    assert calls[1].args[1].midtop == (100, 50 + pad_v)
+    assert calls[2].args[1].midleft == (50 + pad_h, 100)
+    assert calls[3].args[1].midright == (150 - pad_h, 100)
+
+
 def test_animate_sprites_moves_to_destination():
     view, clock = make_view()
     sprite = DummySprite()


### PR DESCRIPTION
## Summary
- add `LABEL_PAD` constant to control spacing for player labels
- offset player name positions by `LABEL_PAD`
- test that label padding is applied

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615b7fb6f883269494ca15eab3ce8a