### PR TITLE
Fix restart_game current trick clearing

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -1373,6 +1373,7 @@ class GameView:
         self._attach_reset_pile()
         self.reset_current_trick()
         self.selected.clear()
+        self.current_trick.clear()
         self.apply_options()
         for p in self.game.players:
             counts.setdefault(p.name, 0)

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -771,6 +771,15 @@ def test_current_trick_reset_on_restart_and_new_round():
     pygame.quit()
 
 
+def test_restart_game_clears_current_trick_immediately():
+    view, _ = make_view()
+    view.current_trick.append(("P1", pygame.Surface((1, 1))))
+    with patch.object(view, "close_overlay"):
+        view.restart_game()
+    assert view.current_trick == []
+    pygame.quit()
+
+
 def test_draw_players_displays_trick_linearly():
     view, _ = make_view()
     view.hand_sprites = pygame.sprite.OrderedUpdates()


### PR DESCRIPTION
## Summary
- ensure current trick list is emptied after restart
- cover restart_game clearing current trick

## Testing
- `pytest tests/test_pygame_gui.py::test_restart_game_clears_current_trick_immediately -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686162271cc48326b8ef62e49c0e5a04