### PR TITLE
Fix score overlay test

### DIFF
--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -718,6 +718,7 @@ def test_draw_score_overlay_positions_panel():
         view, _ = make_view()
     view.screen = MagicMock()
     view.score_pos = (15, 20)
+    view.score_visible = True
     view.screen.get_size.return_value = (300, 200)
     surf = pygame.Surface((200, 20))
     with patch("pygame.Surface", return_value=surf), patch.object(


### PR DESCRIPTION
## Summary
- ensure scoreboard visible when drawing score overlay in test

## Testing
- `pytest tests/test_pygame_gui.py::test_draw_score_overlay_positions_panel -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614fc1ef3c8326ab41dc728d1f3f24