### PR TITLE
Refactor pile drawing into dedicated method

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -1798,10 +1798,7 @@ class GameView:
             color = (0, 255, 0) if valid else (255, 0, 0)
             for sp in self.selected:
                 pygame.draw.rect(self.screen, color, sp.rect, width=3)
-        if not self.game.pile:
-            self.current_trick.clear()
-        if self.current_trick:
-            self.draw_center_pile()
+        self.draw_center_pile()
 
         if self.state == GameState.PLAYING:
             # Enable or disable Undo based on snapshot history
@@ -1814,8 +1811,13 @@ class GameView:
 
     def draw_center_pile(self) -> None:
         """Draw the cards currently in the centre pile."""
-        center_x, y = self._pile_center()
+        if not self.game.pile:
+            if self.current_trick:
+                self.current_trick.clear()
+            return
+
         w, _ = self.screen.get_size()
+        y = self.pile_y
         card_w = self.card_width
         start_rel, overlap = calc_start_and_overlap(
             w, len(self.current_trick), card_w, 25, card_w - 5

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -790,8 +790,8 @@ def test_draw_players_displays_trick_linearly():
     view.current_trick = [("A", surf1), ("B", surf2)]
     view.screen = MagicMock()
     view.screen.get_size.return_value = (200, 200)
-    with patch.object(view, "_pile_center", return_value=(100, 50)):
-        view.draw_players()
+    view.pile_y = 50
+    view.draw_center_pile()
     calls = [c for c in view.screen.blit.call_args_list if c.args[0] in (surf1, surf2)]
     card_w = view.card_width
     start_rel, overlap = pygame_gui.calc_start_and_overlap(


### PR DESCRIPTION
## Summary
- draw pile through new `draw_center_pile()`
- simplify `draw_players()` to call the new helper
- update test to use `draw_center_pile`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617b1bb79083268a6cfe7cd1125053