### PR TITLE
Remove duplicate score button repositioning

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -1526,7 +1526,6 @@ class GameView:
         self._create_action_buttons()
         self._position_score_button()
         self._position_settings_button()
-        self._position_score_button()
         if self.overlay:
             self.overlay.resize()
 


### PR DESCRIPTION
## Summary
- fix on_resize by removing duplicate _position_score_button call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617d9d0cd88326aedfb915370ab8d4