### PR TITLE
Add border to card sprite

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -157,7 +157,16 @@ class CardSprite(pygame.sprite.Sprite):
             # Render a text fallback
             font = pygame.font.SysFont(None, 20)
             img = font.render(str(card), True, (0, 0, 0), (255, 255, 255))
-        self.image = img
+
+        border = 2
+        w, h = img.get_size()
+        surf = pygame.Surface((w + border * 2, h + border * 2), pygame.SRCALPHA)
+        rect = surf.get_rect()
+        pygame.draw.rect(surf, (220, 220, 220), rect, border_radius=5)
+        pygame.draw.rect(surf, (0, 0, 0), rect, width=1, border_radius=5)
+        surf.blit(img, (border, border))
+
+        self.image = surf
         self.rect = self.image.get_rect(topleft=pos)
         self.card = card
         self.selected = False

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -396,13 +396,13 @@ def test_on_resize_rebuilds_sprites():
                 view.update_hand_sprites()
                 start_width = view.card_width
                 first = next(iter(view.hand_sprites))
-                assert first.rect.width == start_width
+                assert first.rect.width >= start_width
 
                 view.on_resize(650, 400)
                 new_width = view.card_width
                 assert new_width != start_width
                 first = next(iter(view.hand_sprites))
-                assert first.rect.width == new_width
+                assert first.rect.width >= new_width
                 load_images.assert_called_with(new_width)
     pygame.quit()
 


### PR DESCRIPTION
## Summary
- render card images onto a slightly larger surface so each card sprite has a border
- relax size assertions in GUI tests to allow the new border

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618cb174b88326968618353b393723