### PR TITLE
Remove unused Save Game from main menu

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -342,31 +342,25 @@ class MainMenuOverlay(Overlay):
                 "New Game", pygame.Rect(bx, by, 200, 40), self.view.restart_game, font
             ),
             Button(
-                "Save Game",
-                pygame.Rect(bx, by + 50, 200, 40),
-                self.view.save_game,
-                font,
-            ),
-            Button(
                 "Load Game",
-                pygame.Rect(bx, by + 100, 200, 40),
+                pygame.Rect(bx, by + 50, 200, 40),
                 self.view.load_game,
                 font,
             ),
             Button(
                 "Settings",
-                pygame.Rect(bx, by + 150, 200, 40),
+                pygame.Rect(bx, by + 100, 200, 40),
                 self.view.show_settings,
                 font,
             ),
             Button(
                 "How to Play",
-                pygame.Rect(bx, by + 200, 200, 40),
+                pygame.Rect(bx, by + 150, 200, 40),
                 lambda: self.view.show_how_to_play(from_menu=True),
                 font,
             ),
             Button(
-                "Quit", pygame.Rect(bx, by + 250, 200, 40), self.view.quit_game, font
+                "Quit", pygame.Rect(bx, by + 200, 200, 40), self.view.quit_game, font
             ),
         ]
         if self.focus_idx >= len(self.buttons):

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -849,15 +849,6 @@ def test_overlay_keyboard_navigation(cls, args):
     pygame.quit()
 
 
-def test_main_menu_has_save_button():
-    view, _ = make_view()
-    overlay = pygame_gui.MainMenuOverlay(view)
-    assert len(overlay.buttons) >= 2
-    btn = overlay.buttons[1]
-    assert btn.text == "Save Game"
-    assert btn.callback == view.save_game
-    pygame.quit()
-
 
 def test_in_game_menu_buttons():
     view, _ = make_view()


### PR DESCRIPTION
## Summary
- remove Save Game button from main menu overlay
- drop related unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619a51db648326b5ad1dabd71bc8f4