### PR TITLE
Refine overlay transitions

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -1157,7 +1157,7 @@ class GameView:
         self,
         old: Optional[Overlay],
         new: Overlay,
-        frames: int = 10,
+        frames: int = 20,
         slide: bool = False,
     ) -> None:
         """Animate transition between two overlays."""
@@ -1178,11 +1178,14 @@ class GameView:
         to_surf = render(new)
 
         current = self.overlay
+        # Draw the base screen once and reuse it during the animation
+        self.overlay = None
+        self._draw_frame()
+        base = self.screen.copy()
+        self.overlay = current
         for i in range(frames):
             progress = (i + 1) / frames
-            self.overlay = None
-            self._draw_frame()
-            self.overlay = current
+            self.screen.blit(base, (0, 0))
             if slide:
                 offset = int(w * (1 - progress))
                 self.screen.blit(from_surf, (-offset, 0))


### PR DESCRIPTION
## Summary
- tweak overlay animation timing for smoother transitions
- capture the base screen once for overlay transitions

## Testing
- `coverage run -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68619bcb95bc832692d26e83a042e565