### PR TITLE
Improve vertical hand layout spacing

### DIFF
--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -1959,14 +1959,21 @@ class GameView:
             sprite = CardSprite(card, (start_x + i * spacing, y), card_w)
             self.hand_sprites.add(sprite)
 
-        vert_spacing = 20
+        margin_v = min(60, max(40, int(card_w * 0.75)))
 
         # --- Left AI player (vertical) ----------------------------------
         left_player = self.game.players[1]
-        total_h = card_h + (len(left_player.hand) - 1) * vert_spacing
-        y_start = screen_h // 2 - total_h // 2
+        start_rel, overlap_v = calc_start_and_overlap(
+            screen_h - 2 * margin_v,
+            len(left_player.hand),
+            card_h,
+            25,
+            card_h - 5,
+        )
+        vert_spacing = card_h - overlap_v
+        y_start = start_rel + margin_v
         for i in range(len(left_player.hand)):
-            pos = (20, y_start + i * vert_spacing)
+            pos = (HORIZONTAL_MARGIN, y_start + i * vert_spacing)
             sprite = CardBackSprite(pos, card_w, self.card_back_name)
             self.ai_sprites[0].add(sprite)
 
@@ -1980,9 +1987,16 @@ class GameView:
 
         # --- Right AI player (vertical) ---------------------------------
         right_player = self.game.players[3]
-        total_h = card_h + (len(right_player.hand) - 1) * vert_spacing
-        y_start = screen_h // 2 - total_h // 2
-        x = screen_w - card_w - 20
+        start_rel, overlap_v = calc_start_and_overlap(
+            screen_h - 2 * margin_v,
+            len(right_player.hand),
+            card_h,
+            25,
+            card_h - 5,
+        )
+        vert_spacing = card_h - overlap_v
+        y_start = start_rel + margin_v
+        x = screen_w - card_w - HORIZONTAL_MARGIN
         for i in range(len(right_player.hand)):
             pos = (x, y_start + i * vert_spacing)
             sprite = CardBackSprite(pos, card_w, self.card_back_name)

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -646,6 +646,41 @@ def test_resize_keeps_sprites_within_margins():
     pygame.quit()
 
 
+def test_vertical_spacing_changes_on_resize():
+    pygame.display.init()
+    surf_small = pygame.Surface((300, 200))
+    surf_large = pygame.Surface((600, 600))
+    set_mode = MagicMock(side_effect=[surf_small, surf_large])
+    with patch("pygame.display.set_mode", set_mode):
+        with patch("pygame.font.SysFont", return_value=DummyFont()):
+            with patch.object(
+                pygame_gui, "load_card_images"
+            ), patch.object(
+                pygame_gui,
+                "get_card_image",
+                side_effect=lambda c, w: pygame.Surface((w, int(w * 1.4))),
+            ), patch.object(
+                pygame_gui,
+                "get_card_back",
+                side_effect=lambda name, w=1: pygame.Surface((w, int(w * 1.4))),
+            ):
+                view = pygame_gui.GameView(300, 200)
+                left_small = view.ai_sprites[1].sprites()
+                spacing_small = (
+                    left_small[1].rect.centery - left_small[0].rect.centery
+                )
+
+                view.on_resize(600, 600)
+
+                left_large = view.ai_sprites[1].sprites()
+                spacing_large = (
+                    left_large[1].rect.centery - left_large[0].rect.centery
+                )
+
+    pygame.quit()
+    assert spacing_large != spacing_small
+
+
 def test_overlay_instances_created():
     view, _ = make_view()
     with patch("pygame.display.flip"), patch("pygame.event.pump"):


### PR DESCRIPTION
## Summary
- compute vertical hand spacing using available screen height
- adjust AI hand placement on the left and right edges to honour margins
- test that vertical spacing updates after resizing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864121be4a08326a2cebadb7b9efe2f