### PR TITLE
Add player avatar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ are handled automatically.
   The *Flip Suit Rank* rule reverses suit ordering and can only be
   enabled from the main menu.
 - On-screen **Play**, **Pass** and **Undo** buttons between your hand and the pile.
+- Optional player avatars loaded from `assets/avatars/`.
 
 Displaying card images requires the **Pillow** library, which is
 included in `requirements.txt`. Install dependencies (including Pillow
@@ -93,6 +94,7 @@ Additional assets can be organised in subdirectories:
 - `assets/card_backs/` for alternative card backs.
 - `assets/tables/` for table textures.
 - `assets/music/` for background tracks.
+- `assets/avatars/` for optional player avatars (initials are shown if no image is found).
 
 Table textures will be tiled to fill the screen and can be switched at
 runtime from the graphics settings menu.

--- a/assets/avatars/README.md
+++ b/assets/avatars/README.md
@@ -1,0 +1,1 @@
+Avatar images for player profiles can be placed here. Each image should be named after the player, e.g. `Player.png`.


### PR DESCRIPTION
## Summary
- add avatar directory and document usage
- allow optional player avatars in `GameView`
- draw avatars beside player labels in Pygame GUI
- fix Player import

## Testing
- `coverage run -m pytest` *(fails: test_vertical_spacing_changes_on_resize)*
- `coverage xml -o coverage.xml`


------
https://chatgpt.com/codex/tasks/task_e_686424a153f8832689931f12f3010b67