### PR TITLE
Remove unused optional rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ are handled automatically.
 - Sprites and layout adapt automatically when the window is resized.
 - Press **Enter** or **Space** for the usual shortcuts.
 - Settings and menu overlays are provided.
-- A dedicated *House Rules* screen lets you toggle optional rules
-  such as “Chặt” bombs, chain cutting and others.
+- A dedicated *House Rules* screen lets you toggle optional rules.
   The *Flip Suit Rank* rule reverses suit ordering and can only be
   enabled from the main menu.
 - On-screen **Play**, **Pass** and **Undo** buttons between your hand and the pile.

--- a/pygame_gui.py
+++ b/pygame_gui.py
@@ -785,13 +785,10 @@ class RulesOverlay(Overlay):
             btn.callback = toggle(attr, label)(btn)
             self.buttons.append(btn)
 
-        make_button(0, "rule_chat_bomb", "“Chặt” Bomb")
-        make_button(50, "rule_chain_cutting", "Chain Cutting")
-        make_button(100, "rule_tu_quy_hierarchy", "Tứ Quý Hierarchy")
-        make_button(150, "rule_flip_suit_rank", "Flip Suit Rank")
-        make_button(200, "rule_no_2s", "No 2s in straights")
+        make_button(0, "rule_flip_suit_rank", "Flip Suit Rank")
+        make_button(50, "rule_no_2s", "No 2s in straights")
         self.buttons.append(
-            Button("Back", pygame.Rect(bx, by + 250, 240, 40), self.back_callback, font)
+            Button("Back", pygame.Rect(bx, by + 100, 240, 40), self.back_callback, font)
         )
 
 
@@ -1089,9 +1086,6 @@ class GameView:
         self.tutorial_mode = False
         self.show_rules_option = False
         # Additional house rule toggles
-        self.rule_chat_bomb = False
-        self.rule_chain_cutting = False
-        self.rule_tu_quy_hierarchy = False
         self.rule_flip_suit_rank = False
         self.rule_no_2s = True
         self.score_visible = True
@@ -1127,13 +1121,6 @@ class GameView:
         self.show_rules_option = opts.get(
             "show_rules_option",
             opts.get("show_rules", self.show_rules_option),
-        )
-        self.rule_chat_bomb = opts.get("rule_chat_bomb", self.rule_chat_bomb)
-        self.rule_chain_cutting = opts.get(
-            "rule_chain_cutting", self.rule_chain_cutting
-        )
-        self.rule_tu_quy_hierarchy = opts.get(
-            "rule_tu_quy_hierarchy", self.rule_tu_quy_hierarchy
         )
         self.rule_flip_suit_rank = opts.get(
             "rule_flip_suit_rank", self.rule_flip_suit_rank
@@ -1704,9 +1691,6 @@ class GameView:
             "house_rules": self.house_rules,
             "tutorial_mode": self.tutorial_mode,
             "show_rules_option": self.show_rules_option,
-            "rule_chat_bomb": self.rule_chat_bomb,
-            "rule_chain_cutting": self.rule_chain_cutting,
-            "rule_tu_quy_hierarchy": self.rule_tu_quy_hierarchy,
             "rule_flip_suit_rank": self.rule_flip_suit_rank,
             "rule_no_2s": self.rule_no_2s,
             "fullscreen": self.fullscreen,
@@ -1750,9 +1734,6 @@ class GameView:
         import tien_len_full as tl
 
         tl.ALLOW_2_IN_SEQUENCE = not self.rule_no_2s
-        tl.CHAT_BOMB = self.rule_chat_bomb
-        tl.CHAIN_CUTTING = self.rule_chain_cutting
-        tl.TU_QUY_HIERARCHY = self.rule_tu_quy_hierarchy
         tl.FLIP_SUIT_RANK = self.rule_flip_suit_rank
         sound.set_volume(self.fx_volume)
         sound.set_enabled(self.sound_enabled)

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -1034,9 +1034,6 @@ def test_options_persist_across_sessions(tmp_path):
         view.colorblind_mode = True
         view.fx_volume = 0.5
         view.music_volume = 0.25
-        view.rule_chat_bomb = True
-        view.rule_chain_cutting = True
-        view.rule_tu_quy_hierarchy = True
         view.rule_flip_suit_rank = True
         view.rule_no_2s = False
         view.fullscreen = True
@@ -1050,9 +1047,6 @@ def test_options_persist_across_sessions(tmp_path):
     assert new_view.colorblind_mode is True
     assert new_view.fx_volume == 0.5
     assert new_view.music_volume == 0.25
-    assert new_view.rule_chat_bomb is True
-    assert new_view.rule_chain_cutting is True
-    assert new_view.rule_tu_quy_hierarchy is True
     assert new_view.rule_flip_suit_rank is True
     assert new_view.rule_no_2s is False
     assert new_view.fullscreen is True
@@ -1067,9 +1061,6 @@ def test_rules_overlay_toggles_update_state():
         pygame_gui.GameView.show_rules(view)
     overlay = view.overlay
     attrs = [
-        "rule_chat_bomb",
-        "rule_chain_cutting",
-        "rule_tu_quy_hierarchy",
         "rule_flip_suit_rank",
         "rule_no_2s",
     ]

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -63,11 +63,7 @@ RANKS = ['3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A', '2']
 # The default preserves the house rule used by the tests which forbids
 # ``2`` in sequences.
 ALLOW_2_IN_SEQUENCE = False
-# Additional optional rules toggles.  These defaults match the behaviour
-# used by the tests and GUI unless overridden.
-CHAT_BOMB = False
-CHAIN_CUTTING = False
-TU_QUY_HIERARCHY = False
+# Additional optional rule toggles used by the tests and GUI.
 FLIP_SUIT_RANK = False
 
 # Helper --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- eliminate unused CHAT_BOMB, CHAIN_CUTTING and TU_QUY_HIERARCHY flags
- drop GUI options for the removed rules
- update docs and tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864315269dc8326a760d500cc6feab2