### PR TITLE
Add CLI personality flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ After installation launch the Pygame GUI with `tien-len`.
 To play in the terminal run:
 
 ```bash
-python3 tien_len_full.py [--ai Easy|Normal|Hard|Expert]
+python3 tien_len_full.py [--ai Easy|Normal|Hard|Expert] \
+                        [--personality aggressive|defensive|balanced|random] \
+                        [--lookahead]
 ```
 
 The optional `--ai` flag selects the AI difficulty (default is `Normal`).
-The game logs actions to `tien_len_game.log`.
+Use `--personality` to choose how boldly opponents play and `--lookahead`
+to enable the extra search step used by the AI.  The game logs actions to
+`tien_len_game.log`.
 
 ## Card notation
 

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -1,0 +1,39 @@
+from tien_len_full import main
+
+
+def run_cli(args):
+    return main(args)
+
+
+def test_personality_and_lookahead_flags(monkeypatch):
+    captured = {}
+
+    def fake_play(self):
+        captured['ai'] = self.ai_level
+        captured['personality'] = self.ai_personality
+        captured['lookahead'] = self.ai_lookahead
+
+    monkeypatch.setattr('tien_len_full.Game.play', fake_play)
+    run_cli(['--ai', 'Hard', '--personality', 'aggressive', '--lookahead'])
+    assert captured == {
+        'ai': 'Hard',
+        'personality': 'aggressive',
+        'lookahead': True,
+    }
+
+
+def test_cli_defaults(monkeypatch):
+    captured = {}
+
+    def fake_play(self):
+        captured['ai'] = self.ai_level
+        captured['personality'] = self.ai_personality
+        captured['lookahead'] = self.ai_lookahead
+
+    monkeypatch.setattr('tien_len_full.Game.play', fake_play)
+    run_cli([])
+    assert captured == {
+        'ai': 'Normal',
+        'personality': 'balanced',
+        'lookahead': False,
+    }

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -927,12 +927,43 @@ class Game:
         self.current_idx = (self.current_idx + 1) % len(self.players)
 
 
-if __name__ == '__main__':
+def create_parser() -> argparse.ArgumentParser:
+    """Return the command line argument parser used by the CLI."""
+
     parser = argparse.ArgumentParser(description='Play Tiến Lên in the terminal')
-    parser.add_argument('--ai', default='Normal', choices=['Easy', 'Normal', 'Hard', 'Expert'],
-                        help='AI difficulty level')
-    args = parser.parse_args()
+    parser.add_argument(
+        '--ai',
+        default='Normal',
+        choices=['Easy', 'Normal', 'Hard', 'Expert'],
+        help='AI difficulty level',
+    )
+    parser.add_argument(
+        '--personality',
+        default='balanced',
+        choices=['aggressive', 'defensive', 'balanced', 'random'],
+        help='AI personality style',
+    )
+    parser.add_argument(
+        '--lookahead',
+        action='store_true',
+        help='Enable AI lookahead when scoring moves',
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> Game:
+    """Run the CLI game and return the :class:`Game` instance used."""
+
+    parser = create_parser()
+    args = parser.parse_args(argv)
 
     game = Game()
     game.set_ai_level(args.ai)
+    game.set_personality(args.personality)
+    game.ai_lookahead = args.lookahead
     game.play()
+    return game
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- extend CLI argument parser
- expose `main()` helper for CLI entry
- document new command line flags in README
- test CLI flag handling

## Testing
- `python -m coverage run -m pytest`
- `python -m coverage xml`

------
https://chatgpt.com/codex/tasks/task_e_68653ae704188326953b743484cee27b