### PR TITLE
Add CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For development you can use the editable mode instead:
 pip install -e .
 ```
 
-After installation launch the Pygame GUI with `tien-len`.
+After installation launch the Pygame GUI with `tien-len` or start the CLI via `tien-len-cli`.
 
 ## CLI version
 
@@ -31,6 +31,7 @@ python3 tien_len_full.py [--ai Easy|Normal|Hard|Expert] \
                         [--personality aggressive|defensive|balanced|random] \
                         [--lookahead]
 ```
+After installation the same game can be started with the `tien-len-cli` command.
 
 The optional `--ai` flag selects the AI difficulty (default is `Normal`).
 Use `--personality` to choose how boldly opponents play and `--lookahead`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = ["pillow", "pygame-ce"]
 [project.gui-scripts]
 tien-len = "pygame_gui:main"
 
+[project.scripts]
+tien-len-cli = "tien_len_full:main"
+
 [tool.setuptools]
 py-modules = [
     "tien_len_full",


### PR DESCRIPTION
## Summary
- add a `tien-len-cli` script entry point
- document the new command in installation and CLI instructions

## Testing
- `python -m pip install -r requirements.txt`
- `python -m coverage run -m pytest`
- `python -m coverage xml`

------
https://chatgpt.com/codex/tasks/task_e_686577c43d888326885fd194f15e3107