### PR TITLE
Fix imports and formatting

### DIFF
--- a/pygame_gui/__init__.py
+++ b/pygame_gui/__init__.py
@@ -8,6 +8,8 @@ from .helpers import (
     ZONE_GUTTER,
     AVATAR_DIR,
     AVATAR_SIZE,
+    OPTIONS_FILE,
+    SAVE_FILE,
     GameState,
     calc_start_and_overlap,
     calc_hand_layout,
@@ -42,7 +44,8 @@ from .view import GameView, main
 
 __all__ = [
     'TABLE_THEMES', 'PLAYER_COLORS', 'HAND_SPACING', 'HORIZONTAL_MARGIN', 'LABEL_PAD',
-    'BUTTON_HEIGHT', 'ZONE_GUTTER', 'AVATAR_DIR', 'AVATAR_SIZE', 'GameState',
+    'BUTTON_HEIGHT', 'ZONE_GUTTER', 'AVATAR_DIR', 'AVATAR_SIZE',
+    'OPTIONS_FILE', 'SAVE_FILE', 'GameState',
     'calc_start_and_overlap', 'calc_hand_layout', 'list_music_tracks', 'list_table_textures',
     'load_card_images', 'get_card_image', 'get_card_back', 'CardSprite', 'CardBackSprite',
     'draw_glow', '_mixer_ready', 'AnimationMixin', 'Button', 'Overlay', 'MainMenuOverlay',

--- a/pygame_gui/helpers.py
+++ b/pygame_gui/helpers.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Tuple, List, Callable, Optional
+from typing import Dict, Tuple, List, Optional
 from enum import Enum, auto
-import json
 import logging
-import math
-import types
 
 import pygame
 
-from tien_len_full import Game, Card, detect_combo, Player
-import sound
+from tien_len_full import Card
 
 LOG_FILE = "tien_len_game.log"
 
@@ -292,5 +288,3 @@ class CardBackSprite(pygame.sprite.Sprite):
 # ---------------------------------------------------------------------------
 # Simple button and overlay helpers
 # ---------------------------------------------------------------------------
-
-

--- a/pygame_gui/overlays.py
+++ b/pygame_gui/overlays.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pygame
 from typing import List, Callable, Optional, TYPE_CHECKING
 
-from .helpers import list_card_back_colors, list_table_textures, get_card_back, TABLE_THEMES
+from .helpers import (
+    list_card_back_colors,
+    list_table_textures,
+    get_card_back,
+    list_music_tracks,
+    TABLE_THEMES,
+)
 
 if TYPE_CHECKING:
     from .view import GameView
@@ -459,7 +465,6 @@ class AudioOverlay(Overlay):
         )
         self.buttons.append(btn)
 
-
 class RulesOverlay(Overlay):
     """Overlay providing toggles for optional house rules."""
 
@@ -716,4 +721,3 @@ class GameOverOverlay(Overlay):
             surface.blit(img, img.get_rect(center=(w // 2, y)))
             y += 30
         super().draw(surface)
-

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -20,6 +20,8 @@ from .helpers import (
     ZONE_GUTTER,
     AVATAR_DIR,
     AVATAR_SIZE,
+    OPTIONS_FILE,
+    SAVE_FILE,
     GameState,
     calc_start_and_overlap,
     calc_hand_layout,
@@ -27,7 +29,6 @@ from .helpers import (
     list_table_textures,
     load_card_images,
     get_card_image,
-    get_card_back,
     CardSprite,
     CardBackSprite,
     draw_glow,
@@ -53,10 +54,8 @@ from .animations import AnimationMixin
 
 logger = logging.getLogger(__name__)
 
-
 class GameView(AnimationMixin):
     TABLE_COLOR = TABLE_THEMES["darkgreen"]
-
 
     def __init__(self, width: int = 1024, height: int = 768) -> None:
         pygame.init()


### PR DESCRIPTION
## Summary
- clean up unused imports in `helpers.py`
- export save file constants for tests
- import `list_music_tracks` in overlays
- remove blank line at EOF and tidy spacing before `RulesOverlay`
- remove unused get_card_back import in view and pull options constants

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: 18 failed, 101 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6865e6eb3cc88326936999d34536db32