### PR TITLE
Fix Python 3.8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains a simple command line implementation of the
 Vietnamese card game **Tiến Lên**. It comes with a Pygame graphical
 interface implemented in `pygame_gui.py`.
 
+This project requires **Python 3.8** or later.
+
 ## Installation
 
 Install the project with `pip` to make the Pygame GUI entry point available:

--- a/sound.py
+++ b/sound.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Union
 import warnings
 
 try:
@@ -16,7 +17,7 @@ _SOUNDS: dict[str, "pygame.mixer.Sound"] = {}
 _VOLUME = 1.0
 
 
-def load(name: str, path: str | Path) -> bool:
+def load(name: str, path: Union[str, Path]) -> bool:
     """Load a sound effect from ``path`` under ``name``.
 
     Returns ``True`` on success.  Loading does nothing if the mixer is


### PR DESCRIPTION
## Summary
- fix Union type annotation for `sound.load`
- document minimum Python version in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865f33aabf48326b2e7d227458ad709