### PR TITLE
Fix tests and option handling

### DIFF
--- a/pygame_gui/animations.py
+++ b/pygame_gui/animations.py
@@ -6,7 +6,13 @@ from typing import List, Tuple, Optional
 
 import pygame
 
-from .helpers import CardSprite, get_card_back
+from .helpers import CardSprite
+
+def get_card_back(*args, **kwargs):
+    """Proxy to pygame_gui.get_card_back for easy patching in tests."""
+    import pygame_gui
+
+    return pygame_gui.get_card_back(*args, **kwargs)
 from .overlays import Overlay
 
 

--- a/pygame_gui/helpers.py
+++ b/pygame_gui/helpers.py
@@ -204,7 +204,10 @@ def get_card_image(card: Card, width: int) -> pygame.Surface:
 class CardSprite(pygame.sprite.Sprite):
     def __init__(self, card: Card, pos: Tuple[int, int], width: int = 80) -> None:
         super().__init__()
-        img = get_card_image(card, width)
+        # Import at runtime to allow tests to patch the public helper
+        import pygame_gui
+
+        img = pygame_gui.get_card_image(card, width)
         if img is None:
             # Render a text fallback
             font = pygame.font.SysFont(None, 20)
@@ -275,7 +278,10 @@ class CardBackSprite(pygame.sprite.Sprite):
         rotation: int = 0,
     ) -> None:
         super().__init__()
-        img = get_card_back(name, width)
+        # Import at runtime so tests can patch the function via the package
+        import pygame_gui
+
+        img = pygame_gui.get_card_back(name, width)
         if img is None:
             font = pygame.font.SysFont(None, 20)
             img = font.render("[]", True, (0, 0, 0), (255, 255, 255))


### PR DESCRIPTION
## Summary
- fix card sprite image helpers for easier patching in tests
- proxy `get_card_back` in `animations` to allow patching
- ensure pygame GUI uses public helpers for card images and loading
- isolate options file handling during tests
- adjust mixer checks to use package-level helper

## Testing
- `python -m coverage run -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68666b410cf48326b8accffda5441051