### PR TITLE
Fix flake8 import order violation

### DIFF
--- a/pygame_gui/helpers.py
+++ b/pygame_gui/helpers.py
@@ -9,10 +9,10 @@ import logging
 
 import pygame
 
+from tien_len_full import Card
+
 # Path to the installed assets directory
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
-
-from tien_len_full import Card
 
 LOG_FILE = "tien_len_game.log"
 


### PR DESCRIPTION
## Summary
- address E402 flake8 error by grouping the `Card` import with other imports

## Testing
- `flake8`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68670ab410f48326ad844de5d63d6b0a