### PR TITLE
Update avatar loading and profile options

### DIFF
--- a/pygame_gui/overlays.py
+++ b/pygame_gui/overlays.py
@@ -146,19 +146,25 @@ class MainMenuOverlay(Overlay):
                 font,
             ),
             Button(
-                "Settings",
+                "Switch Profile",
                 pygame.Rect(bx, by + 100, 200, 40),
+                self.view.show_profile_select,
+                font,
+            ),
+            Button(
+                "Settings",
+                pygame.Rect(bx, by + 150, 200, 40),
                 self.view.show_settings,
                 font,
             ),
             Button(
                 "How to Play",
-                pygame.Rect(bx, by + 150, 200, 40),
+                pygame.Rect(bx, by + 200, 200, 40),
                 lambda: self.view.show_how_to_play(from_menu=True),
                 font,
             ),
             Button(
-                "Quit", pygame.Rect(bx, by + 200, 200, 40), self.view.quit_game, font
+                "Quit", pygame.Rect(bx, by + 250, 200, 40), self.view.quit_game, font
             ),
         ]
         if self.focus_idx >= len(self.buttons):

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -185,7 +185,7 @@ class GameView(AnimationMixin):
         self.apply_options()
         self.update_hand_sprites()
         self._create_action_buttons()
-        self.show_profile_select()
+        self.show_menu()
 
     # Animation helpers -------------------------------------------------
     def _draw_frame(self) -> None:
@@ -271,15 +271,21 @@ class GameView(AnimationMixin):
         """Load avatar images for all players if available."""
         self.avatars.clear()
         for p in self.game.players:
-            filename = p.name.lower().replace(" ", "_") + ".png"
-            path = AVATAR_DIR / filename
-            if path.exists():
-                try:
-                    img = pygame.image.load(str(path)).convert_alpha()
-                    img = pygame.transform.smoothscale(img, (AVATAR_SIZE, AVATAR_SIZE))
-                    self.avatars[p.name] = img
-                except Exception:
-                    continue
+            base = p.name.lower().replace(" ", "_")
+            candidates = []
+            if not getattr(p, "is_human", False):
+                candidates.append(base + "_icon.png")
+            candidates.append(base + ".png")
+            for name in candidates:
+                path = AVATAR_DIR / name
+                if path.exists():
+                    try:
+                        img = pygame.image.load(str(path)).convert_alpha()
+                        img = pygame.transform.smoothscale(img, (AVATAR_SIZE, AVATAR_SIZE))
+                        self.avatars[p.name] = img
+                        break
+                    except Exception:
+                        continue
 
     def _avatar_for(self, player: "Player") -> pygame.Surface:
         """Return avatar image or a placeholder with player initials."""


### PR DESCRIPTION
## Summary
- show the main menu on startup instead of the profile selector
- load AI avatars using `*_icon.png` images
- add a **Switch Profile** option to the main menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686711c5cff8832690b736edc658d1a3