### PR TITLE
Fix coverage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ Tests that exercise the graphical interfaces require the optional
 tests when the dependencies are not available.
 
 Coverage statistics exclude the GUI module because automated testing of
-its interface is impractical. The `.coveragerc` file lists the
-`pygame_gui` package under the `omit` section.
+its interface is impractical. The `.coveragerc` file lists
+`pygame_gui/*.py` under the `omit` section.
 
 ## Debugging
 


### PR DESCRIPTION
## Summary
- fix coverage docs to show the `pygame_gui/*.py` pattern

## Testing
- `pip install -r requirements.txt`
- `coverage run -m pytest`
- `coverage xml`


------
https://chatgpt.com/codex/tasks/task_e_6867b8ae968c83268f035421bd015006