### PR TITLE
Add player zone highlight and tests

### DIFF
--- a/pygame_gui/__init__.py
+++ b/pygame_gui/__init__.py
@@ -11,6 +11,8 @@ from .helpers import (
     ASSETS_DIR,
     OPTIONS_FILE,
     SAVE_FILE,
+    ZONE_BG,
+    ZONE_HIGHLIGHT,
     GameState,
     calc_start_and_overlap,
     calc_hand_layout,
@@ -46,7 +48,7 @@ from .view import GameView, main
 __all__ = [
     'TABLE_THEMES', 'PLAYER_COLORS', 'HAND_SPACING', 'HORIZONTAL_MARGIN', 'LABEL_PAD',
     'BUTTON_HEIGHT', 'ZONE_GUTTER', 'AVATAR_DIR', 'AVATAR_SIZE', 'ASSETS_DIR',
-    'OPTIONS_FILE', 'SAVE_FILE', 'GameState',
+    'OPTIONS_FILE', 'SAVE_FILE', 'ZONE_BG', 'ZONE_HIGHLIGHT', 'GameState',
     'calc_start_and_overlap', 'calc_hand_layout', 'list_music_tracks', 'list_table_textures',
     'load_card_images', 'get_card_image', 'get_card_back', 'CardSprite', 'CardBackSprite',
     'draw_glow', '_mixer_ready', 'AnimationMixin', 'Button', 'Overlay', 'MainMenuOverlay',

--- a/pygame_gui/helpers.py
+++ b/pygame_gui/helpers.py
@@ -65,6 +65,10 @@ BUTTON_HEIGHT = 40
 ZONE_GUTTER = 10
 AVATAR_DIR = ASSETS_DIR / "avatars"
 AVATAR_SIZE = 40
+# Background colour for player hand zones
+ZONE_BG = (0, 0, 0, 100)
+# Glow color for the active player's zone
+ZONE_HIGHLIGHT = (255, 255, 0)
 
 # Helper for positioning card sequences
 

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -261,6 +261,36 @@ def test_draw_players_labels_use_padding():
     assert calls[3].args[1].midright == (150 - pad_h, 100)
 
 
+def test_player_zone_rect_returns_union():
+    view, _ = make_view()
+    view.hand_sprites = pygame.sprite.OrderedUpdates()
+    view.ai_sprites = [pygame.sprite.Group() for _ in range(3)]
+    rects = [pygame.Rect(1, 2, 4, 5), pygame.Rect(4, 10, 2, 3)]
+    sprites = [DummySprite() for _ in rects]
+    for sp, r in zip(sprites, rects):
+        sp.rect = r
+    view.hand_sprites.add(*sprites)
+    zone = view._player_zone_rect(0)
+    assert zone.topleft == (1, 2)
+    assert zone.bottomright == (6, 13)
+
+
+def test_draw_players_highlights_active_zone():
+    view, _ = make_view()
+    view.screen = MagicMock()
+    view.screen.get_size.return_value = (100, 100)
+    view.hand_sprites = pygame.sprite.OrderedUpdates()
+    view.ai_sprites = [pygame.sprite.Group() for _ in range(3)]
+    zone = pygame.Rect(0, 0, 10, 10)
+    with patch.object(view, "_player_zone_rect", return_value=zone), patch.object(
+        pygame_gui.view, "draw_glow"
+    ) as glow:
+        view.game.current_idx = 2
+        view.draw_players()
+    assert glow.call_count == 1
+    glow.assert_called_with(view.screen, zone, pygame_gui.ZONE_HIGHLIGHT)
+
+
 def test_animate_sprites_moves_to_destination():
     view, clock = make_view()
     sprite = DummySprite()


### PR DESCRIPTION
## Summary
- add ZONE_BG and ZONE_HIGHLIGHT constants
- compute player zone rectangles and highlight active zone
- expose new constants via package init
- tests for zone rectangle calculation and highlight logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ba5d43e483268461b2f17b08878d