### PR TITLE
Add draw_surface_shadow helper and tests

### DIFF
--- a/pygame_gui/__init__.py
+++ b/pygame_gui/__init__.py
@@ -23,6 +23,7 @@ from .helpers import (
     get_card_back,
     CardSprite,
     CardBackSprite,
+    draw_surface_shadow,
     draw_glow,
     _mixer_ready,
 )
@@ -51,7 +52,7 @@ __all__ = [
     'OPTIONS_FILE', 'SAVE_FILE', 'ZONE_BG', 'ZONE_HIGHLIGHT', 'GameState',
     'calc_start_and_overlap', 'calc_hand_layout', 'list_music_tracks', 'list_table_textures',
     'load_card_images', 'get_card_image', 'get_card_back', 'CardSprite', 'CardBackSprite',
-    'draw_glow', '_mixer_ready', 'AnimationMixin', 'Button', 'Overlay', 'MainMenuOverlay',
+    'draw_surface_shadow', 'draw_glow', '_mixer_ready', 'AnimationMixin', 'Button', 'Overlay', 'MainMenuOverlay',
     'InGameMenuOverlay', 'SettingsOverlay', 'GameSettingsOverlay', 'GraphicsOverlay',
     'AudioOverlay', 'RulesOverlay', 'HowToPlayOverlay', 'TutorialOverlay', 'SavePromptOverlay',
     'ProfileOverlay', 'GameOverOverlay', 'GameView', 'main'

--- a/pygame_gui/helpers.py
+++ b/pygame_gui/helpers.py
@@ -257,6 +257,24 @@ class CardSprite(pygame.sprite.Sprite):
                 surface.blit(shadow, rect)
 
 
+def draw_surface_shadow(
+    surface: pygame.Surface,
+    image: pygame.Surface,
+    rect: pygame.Rect,
+    offset: Tuple[int, int] = (5, 5),
+    blur: int = 2,
+    alpha: int = 80,
+) -> None:
+    """Draw a simple blurred shadow beneath ``image`` at ``rect``."""
+    shadow = pygame.Surface(image.get_size(), pygame.SRCALPHA)
+    shadow.fill((0, 0, 0))
+    shadow.set_alpha(alpha)
+    for dx in range(-blur, blur + 1):
+        for dy in range(-blur, blur + 1):
+            r = rect.move(offset[0] + dx, offset[1] + dy)
+            surface.blit(shadow, r)
+
+
 def draw_glow(
     surface: pygame.Surface,
     rect: pygame.Rect,

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -33,6 +33,7 @@ from .helpers import (
     list_table_textures,
     CardSprite,
     CardBackSprite,
+    draw_surface_shadow,
     draw_glow,
 )
 from .overlays import (
@@ -1022,6 +1023,7 @@ class GameView(AnimationMixin):
             )
             color = PLAYER_COLORS[player_idx]
             draw_glow(self.screen, rect, color)
+            draw_surface_shadow(self.screen, img, rect)
             self.screen.blit(img, rect)
 
     def draw_score_overlay(self) -> None:

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -201,6 +201,16 @@ def test_card_sprite_draw_shadow_blits():
     pygame.quit()
 
 
+def test_draw_surface_shadow_blits():
+    pygame.display.init()
+    target = MagicMock()
+    img = pygame.Surface((1, 1), pygame.SRCALPHA)
+    rect = img.get_rect()
+    pygame_gui.draw_surface_shadow(target, img, rect)
+    assert target.blit.call_count > 0
+    pygame.quit()
+
+
 def test_draw_glow_blits():
     pygame.display.init()
     target = MagicMock()
@@ -877,6 +887,20 @@ def test_draw_players_displays_trick_linearly():
     for call in calls:
         surf, rect = call.args
         assert rect.center == expected[surf]
+    pygame.quit()
+
+
+def test_draw_center_pile_uses_shadow_helper():
+    view, _ = make_view()
+    img = pygame.Surface((10, 20))
+    view.current_trick = [("P1", img)]
+    view.screen = MagicMock()
+    view.screen.get_size.return_value = (100, 100)
+    view.pile_y = 40
+    view.game.pile.append((view.game.players[0], []))
+    with patch.object(pygame_gui.view, "draw_surface_shadow") as shadow:
+        view.draw_center_pile()
+        shadow.assert_called_once()
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- implement `draw_surface_shadow` for drawing drop shadows on arbitrary surfaces
- expose new helper through package
- use helper when drawing the center pile of cards
- cover helper and its usage with tests

## Testing
- `pytest -k pygame_gui -q`

------
https://chatgpt.com/codex/tasks/task_e_6867bed30dc48326aa4328870d5cfca2