### PR TITLE
Add shadow constants and tests

### DIFF
--- a/pygame_gui/helpers.py
+++ b/pygame_gui/helpers.py
@@ -70,6 +70,11 @@ ZONE_BG = (0, 0, 0, 100)
 # Glow color for the active player's zone
 ZONE_HIGHLIGHT = (255, 255, 0)
 
+# Shadow drawing defaults
+SHADOW_OFFSET = (5, 5)
+SHADOW_BLUR = 2
+SHADOW_ALPHA = 80
+
 # Helper for positioning card sequences
 
 
@@ -183,7 +188,7 @@ def load_card_images(width: int = 80) -> None:
         )
 
     # Rebuild the shadow cache when card sizes change
-    global _SHADOW_CACHE, _SHADOW_SIZE
+    global _SHADOW_SIZE
     if _BASE_IMAGES:
         sample = next(iter(_BASE_IMAGES.values()))
         ratio = sample.get_height() / sample.get_width()
@@ -257,12 +262,11 @@ class CardSprite(pygame.sprite.Sprite):
     def draw_shadow(
         self,
         surface: pygame.Surface,
-        offset: Tuple[int, int] = (5, 5),
-        blur: int = 2,
-        alpha: int = 80,
+        offset: Tuple[int, int] = SHADOW_OFFSET,
+        blur: int = SHADOW_BLUR,
+        alpha: int = SHADOW_ALPHA,
     ) -> None:
         """Draw a simple blurred shadow beneath the card."""
-        global _SHADOW_CACHE
         size = self.image.get_size()
         base = _SHADOW_CACHE.get(size)
         if base is None:
@@ -281,9 +285,9 @@ def draw_surface_shadow(
     surface: pygame.Surface,
     image: pygame.Surface,
     rect: pygame.Rect,
-    offset: Tuple[int, int] = (5, 5),
-    blur: int = 2,
-    alpha: int = 80,
+    offset: Tuple[int, int] = SHADOW_OFFSET,
+    blur: int = SHADOW_BLUR,
+    alpha: int = SHADOW_ALPHA,
 ) -> None:
     """Draw a simple blurred shadow beneath ``image`` at ``rect``."""
     shadow = pygame.Surface(image.get_size(), pygame.SRCALPHA)

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -202,6 +202,34 @@ def test_card_sprite_draw_shadow_blits():
     pygame.quit()
 
 
+def test_card_sprite_draw_shadow_uses_default_constants():
+    pygame.display.init()
+    with patch("pygame.font.SysFont", return_value=DummyFont()):
+        with patch.object(
+            pygame_gui,
+            "get_card_image",
+            return_value=pygame.Surface((1, 1), pygame.SRCALPHA),
+        ):
+            sprite = pygame_gui.CardSprite(tien_len_full.Card("Spades", "3"), (0, 0), 1)
+    from pygame_gui import helpers as h
+    h._SHADOW_CACHE.clear()
+    base = MagicMock()
+    shadow = MagicMock()
+    base.copy.return_value = shadow
+    h._SHADOW_CACHE[sprite.image.get_size()] = base
+    surf = MagicMock()
+    sprite.draw_shadow(surf)
+    shadow.set_alpha.assert_called_once_with(pygame_gui.SHADOW_ALPHA)
+    expected = (pygame_gui.SHADOW_BLUR * 2 + 1) ** 2
+    assert surf.blit.call_count == expected
+    first = surf.blit.call_args_list[0].args[1]
+    dx = first.x - sprite.rect.x
+    dy = first.y - sprite.rect.y
+    assert dx == pygame_gui.SHADOW_OFFSET[0] - pygame_gui.SHADOW_BLUR
+    assert dy == pygame_gui.SHADOW_OFFSET[1] - pygame_gui.SHADOW_BLUR
+    pygame.quit()
+
+
 def test_draw_shadow_cache_cleared_on_size_change():
     pygame.display.init()
     from pygame_gui import helpers as h
@@ -239,6 +267,25 @@ def test_draw_surface_shadow_blits():
     rect = img.get_rect()
     pygame_gui.draw_surface_shadow(target, img, rect)
     assert target.blit.call_count > 0
+    pygame.quit()
+
+
+def test_draw_surface_shadow_uses_default_constants():
+    pygame.display.init()
+    target = MagicMock()
+    img = pygame.Surface((2, 2), pygame.SRCALPHA)
+    rect = img.get_rect()
+    shadow = MagicMock()
+    with patch("pygame.Surface", return_value=shadow):
+        pygame_gui.draw_surface_shadow(target, img, rect)
+    shadow.set_alpha.assert_called_once_with(pygame_gui.SHADOW_ALPHA)
+    expected = (pygame_gui.SHADOW_BLUR * 2 + 1) ** 2
+    assert target.blit.call_count == expected
+    first = target.blit.call_args_list[0].args[1]
+    dx = first.x - rect.x
+    dy = first.y - rect.y
+    assert dx == pygame_gui.SHADOW_OFFSET[0] - pygame_gui.SHADOW_BLUR
+    assert dy == pygame_gui.SHADOW_OFFSET[1] - pygame_gui.SHADOW_BLUR
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- centralize shadow defaults in pygame_gui.helpers
- use them in CardSprite.draw_shadow and draw_surface_shadow
- test that these defaults are honoured

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c1dcdabc83269dcc6602b97a1e08