### PR TITLE
Fix bottom-hand alignment across window sizes

### DIFF
--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -16,7 +16,6 @@ from .helpers import (
     PLAYER_COLORS,
     HAND_SPACING,
     HORIZONTAL_MARGIN,
-    BOTTOM_MARGIN,
     LABEL_PAD,
     BUTTON_HEIGHT,
     ZONE_GUTTER,
@@ -874,7 +873,7 @@ class GameView(AnimationMixin):
         # --- Human player at the bottom ---------------------------------
         player = self.game.players[0]
         start_x, spacing = calc_hand_layout(screen_w, card_w, len(player.hand))
-        y = screen_h - card_h - BOTTOM_MARGIN
+        y = self.hand_y - card_h // 2
         for i, card in enumerate(player.hand):
             sprite = CardSprite(card, (start_x + i * spacing, y), card_w)
             self.hand_sprites.add(sprite)

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -699,6 +699,7 @@ def test_on_resize_repositions_layout():
                 btn_large_x = [b.rect.x for b in view.action_buttons]
                 btn_large_y = [b.rect.y for b in view.action_buttons]
                 settings_large = view.settings_button.rect.topright
+                hand_center = view.hand_sprites.sprites()[0].rect.centery
 
                 card_w = view.card_width
                 card_h = int(card_w * 1.4)
@@ -715,6 +716,7 @@ def test_on_resize_repositions_layout():
     assert pos_large == expected_pos
     assert btn_large_x[0] == start_x
     assert btn_large_y[0] == expected_y
+    assert hand_center == pos_large[1]
     assert settings_large == expected_settings
     assert pos_small != pos_large
     assert btn_small_x[0] != btn_large_x[0]


### PR DESCRIPTION
## Summary
- remove unused `BOTTOM_MARGIN` import
- calculate bottom-hand position from `hand_y`
- verify resize keeps bottom-hand centred

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c93d324883268689d1787a78951a