### PR TITLE
Add dynamic margin helpers

### DIFF
--- a/pygame_gui/__init__.py
+++ b/pygame_gui/__init__.py
@@ -3,6 +3,8 @@ from .helpers import (
     PLAYER_COLORS,
     HAND_SPACING,
     HORIZONTAL_MARGIN,
+    horizontal_margin,
+    bottom_margin,
     LABEL_PAD,
     BUTTON_HEIGHT,
     ZONE_GUTTER,
@@ -50,7 +52,7 @@ from .overlays import (
 from .view import GameView, main
 
 __all__ = [
-    'TABLE_THEMES', 'PLAYER_COLORS', 'HAND_SPACING', 'HORIZONTAL_MARGIN', 'LABEL_PAD',
+    'TABLE_THEMES', 'PLAYER_COLORS', 'HAND_SPACING', 'HORIZONTAL_MARGIN', 'horizontal_margin', 'bottom_margin', 'LABEL_PAD',
     'BUTTON_HEIGHT', 'ZONE_GUTTER', 'AVATAR_DIR', 'AVATAR_SIZE', 'ASSETS_DIR',
     'OPTIONS_FILE', 'SAVE_FILE', 'ZONE_BG', 'ZONE_HIGHLIGHT', 'GameState',
     'calc_start_and_overlap', 'calc_hand_layout', 'list_music_tracks', 'list_table_textures',

--- a/pygame_gui/helpers.py
+++ b/pygame_gui/helpers.py
@@ -58,6 +58,21 @@ HAND_SPACING = 20
 HORIZONTAL_MARGIN = 20
 # Vertical margin below the human player's hand
 BOTTOM_MARGIN = 20
+
+# ---------------------------------------------------------------------------
+# Margin helpers
+# ---------------------------------------------------------------------------
+
+
+def horizontal_margin(card_width: int) -> int:
+    """Return a horizontal margin size based on ``card_width``."""
+    return min(60, max(40, int(card_width * 0.75)))
+
+
+def bottom_margin(card_width: int) -> int:
+    """Return the bottom margin below the player's hand."""
+    return min(60, max(40, int(card_width * 0.75)))
+
 # Extra padding used when positioning player labels
 LABEL_PAD = 10
 # Button dimensions and layout spacing
@@ -107,15 +122,16 @@ def calc_start_and_overlap(
 def calc_hand_layout(screen_width: int, card_width: int, count: int) -> tuple[int, int]:
     """Return ``(start_x, spacing)`` for a horizontal hand."""
 
+    margin = horizontal_margin(card_width)
     start_rel, overlap = calc_start_and_overlap(
-        screen_width - 2 * HORIZONTAL_MARGIN,
+        screen_width - 2 * margin,
         count,
         card_width,
         25,
         card_width - 5,
     )
     spacing = card_width - overlap
-    return start_rel + HORIZONTAL_MARGIN, spacing
+    return start_rel + margin, spacing
 
 
 # ---------------------------------------------------------------------------

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -28,6 +28,8 @@ from .helpers import (
     GameState,
     calc_start_and_overlap,
     calc_hand_layout,
+    horizontal_margin,
+    bottom_margin,
     list_music_tracks,
     list_table_textures,
     CardSprite,
@@ -217,7 +219,7 @@ class GameView(AnimationMixin):
         """Update stored vertical positions for hand, pile, and buttons."""
         card_h = int(self.card_width * 1.4)
         _, h = self.screen.get_size()
-        margin = min(60, max(40, int(self.card_width * 0.75)))
+        margin = bottom_margin(self.card_width)
         self.hand_y = h - margin - card_h // 2
         self.pile_y = self.hand_y - card_h - ZONE_GUTTER
         self.button_y = self.hand_y + card_h // 2 + ZONE_GUTTER
@@ -230,7 +232,7 @@ class GameView(AnimationMixin):
         w, h = self.screen.get_size()
         card_w = self.card_width
         card_h = int(self.card_width * 1.4)
-        margin = min(60, max(40, int(card_w * 0.75)))
+        margin = bottom_margin(card_w)
         bottom_y = self.hand_y
         top_y = margin + card_h // 2
         left_x = margin + card_w // 2
@@ -878,7 +880,7 @@ class GameView(AnimationMixin):
             sprite = CardSprite(card, (start_x + i * spacing, y), card_w)
             self.hand_sprites.add(sprite)
 
-        margin_v = min(60, max(40, int(card_w * 0.75)))
+        margin_v = bottom_margin(card_w)
 
         # --- Top AI player (horizontal) ---------------------------------
         top_player = self.game.players[2]
@@ -899,8 +901,9 @@ class GameView(AnimationMixin):
         )
         vert_spacing = card_h - overlap_v
         y_start = start_rel + margin_v
+        margin_h = horizontal_margin(card_w)
         for i in range(len(left_player.hand)):
-            pos = (HORIZONTAL_MARGIN, y_start + i * vert_spacing)
+            pos = (margin_h, y_start + i * vert_spacing)
             sprite = CardBackSprite(pos, card_w, self.card_back_name)
             self.ai_sprites[1].add(sprite)
 
@@ -915,7 +918,7 @@ class GameView(AnimationMixin):
         )
         vert_spacing = card_h - overlap_v
         y_start = start_rel + margin_v
-        x = screen_w - card_w - HORIZONTAL_MARGIN
+        x = screen_w - card_w - margin_h
         for i in range(len(right_player.hand)):
             pos = (x, y_start + i * vert_spacing)
             sprite = CardBackSprite(pos, card_w, self.card_back_name)

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -745,7 +745,7 @@ def test_resize_keeps_sprites_within_margins():
 
                 w, h = view.screen.get_size()
                 card_w = view.card_width
-                margin_h = pygame_gui.HORIZONTAL_MARGIN
+                margin_h = pygame_gui.horizontal_margin(card_w)
                 margin_v = min(60, max(40, int(card_w * 0.75)))
 
                 hand = view.hand_sprites.sprites()
@@ -990,14 +990,15 @@ def test_calc_hand_layout_wraps_start_and_spacing():
     card_w = 50
     count = 3
     start, spacing = pygame_gui.calc_hand_layout(width, card_w, count)
+    margin = pygame_gui.horizontal_margin(card_w)
     start_rel, overlap = pygame_gui.calc_start_and_overlap(
-        width - 2 * pygame_gui.HORIZONTAL_MARGIN,
+        width - 2 * margin,
         count,
         card_w,
         25,
         card_w - 5,
     )
-    assert start == start_rel + pygame_gui.HORIZONTAL_MARGIN
+    assert start == start_rel + margin
     assert spacing == card_w - overlap
 
 


### PR DESCRIPTION
## Summary
- add `horizontal_margin` and `bottom_margin` utilities
- use them in `calc_hand_layout()` and view rendering
- update related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867cacfd128832686ca0cef681ef681