### PR TITLE
Fix hand sprite center after resize

### DIFF
--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -883,6 +883,7 @@ class GameView(AnimationMixin):
         y = self.hand_y - card_h // 2
         for i, card in enumerate(player.hand):
             sprite = CardSprite(card, (start_x + i * spacing, y), card_w)
+            sprite.rect.centery = self.hand_y
             self.hand_sprites.add(sprite)
 
         margin_v = bottom_margin(card_w)


### PR DESCRIPTION
## Summary
- ensure player's hand sprites align with computed positions when window size changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d6a80ad883268f8c31800580a8b6