### PR TITLE
Initialize pygame font module before rendering

### DIFF
--- a/pygame_gui/helpers.py
+++ b/pygame_gui/helpers.py
@@ -39,6 +39,8 @@ _FONT_CACHE: Dict[int, pygame.font.Font] = {}
 
 def get_font(size: int) -> pygame.font.Font:
     """Return a cached ``pygame.font.Font`` for ``size``."""
+    # Ensure the font module is initialised. Calling ``init`` repeatedly is safe.
+    pygame.font.init()
     if size not in _FONT_CACHE:
         _FONT_CACHE[size] = pygame.font.SysFont(None, size)
     return _FONT_CACHE[size]

--- a/tests/test_get_font.py
+++ b/tests/test_get_font.py
@@ -1,0 +1,25 @@
+import pytest
+pytest.importorskip("pygame")
+
+import pygame
+import pygame_gui
+
+class DummyFont:
+    def render(self, *args, **kwargs):
+        return pygame.Surface((1, 1))
+
+
+def test_get_font_initializes_pygame_font(monkeypatch):
+    calls = []
+
+    def fake_init():
+        calls.append(True)
+
+    monkeypatch.setattr(pygame.font, "init", fake_init)
+    monkeypatch.setattr(pygame.font, "SysFont", lambda name, size: DummyFont())
+
+    # Clear any cached fonts so the function creates a new one
+    pygame_gui._FONT_CACHE.clear()
+
+    pygame_gui.get_font(12)
+    assert calls == [True]


### PR DESCRIPTION
## Summary
- ensure `pygame.font` is initialized in `get_font`
- add regression test for font initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675177b22c83269d6e2079c42cd2f2