### PR TITLE
Enable double buffering and 60 FPS

### DIFF
--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -70,7 +70,8 @@ class GameView(AnimationMixin):
         pygame.display.set_caption("Tiến Lên - Pygame")
         self.window_width = width
         self.window_height = height
-        self.screen = pygame.display.set_mode((width, height), pygame.RESIZABLE)
+        flags = pygame.RESIZABLE | pygame.DOUBLEBUF
+        self.screen = pygame.display.set_mode((width, height), flags)
         self.fullscreen = False
         self.card_width = self._calc_card_width(width)
         self.clock = pygame.time.Clock()
@@ -694,7 +695,11 @@ class GameView(AnimationMixin):
 
     def on_resize(self, width: int, height: int) -> None:
         """Handle window resize by recreating sprites."""
-        flags = pygame.FULLSCREEN if self.fullscreen else pygame.RESIZABLE
+        flags = (
+            pygame.FULLSCREEN | pygame.DOUBLEBUF
+            if self.fullscreen
+            else pygame.RESIZABLE | pygame.DOUBLEBUF
+        )
         self.window_width = width
         self.window_height = height
         self.screen = pygame.display.set_mode((width, height), flags)
@@ -719,7 +724,11 @@ class GameView(AnimationMixin):
         except Exception:
             pass
         self.fullscreen = not getattr(self, "fullscreen", False)
-        flags = pygame.FULLSCREEN if self.fullscreen else pygame.RESIZABLE
+        flags = (
+            pygame.FULLSCREEN | pygame.DOUBLEBUF
+            if self.fullscreen
+            else pygame.RESIZABLE | pygame.DOUBLEBUF
+        )
         size = self.screen.get_size()
         self.window_width, self.window_height = size
         self.screen = pygame.display.set_mode(size, flags)
@@ -1130,7 +1139,7 @@ class GameView(AnimationMixin):
                     self._dispatch_game_event(event)
 
             self._draw_frame()
-            self.clock.tick(30)
+            self.clock.tick(60)
         pygame.quit()
 
 

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -616,12 +616,16 @@ def test_toggle_fullscreen_sets_flags_and_rescales():
                     set_mode.reset_mock()
 
                     view.toggle_fullscreen()
-                    set_mode.assert_called_with((300, 200), pygame.FULLSCREEN)
+                    set_mode.assert_called_with(
+                        (300, 200), pygame.FULLSCREEN | pygame.DOUBLEBUF
+                    )
                     load_images.assert_called_with(view.card_width)
                     fs_width = view.card_width
 
                     view.toggle_fullscreen()
-                    set_mode.assert_called_with((300, 200), pygame.RESIZABLE)
+                    set_mode.assert_called_with(
+                        (300, 200), pygame.RESIZABLE | pygame.DOUBLEBUF
+                    )
                     assert load_images.call_args_list[-1][0][0] == view.card_width
                     assert view.card_width == fs_width  # width unchanged for same size
     pygame.quit()
@@ -735,7 +739,7 @@ def test_on_resize_updates_screen_size():
         view, "_create_action_buttons"
     ) as cab:
         view.on_resize(300, 200)
-    sm.assert_called_with((300, 200), pygame.RESIZABLE)
+    sm.assert_called_with((300, 200), pygame.RESIZABLE | pygame.DOUBLEBUF)
     uh.assert_called_once()
     cab.assert_called_once()
 


### PR DESCRIPTION
## Summary
- enable `pygame.DOUBLEBUF` for GameView display surfaces
- tick the main loop at 60 FPS
- update tests for new flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f04976fc832691e81843b1219d84