### PR TITLE
Fix DummyClock tick

### DIFF
--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -22,6 +22,7 @@ class DummyClock:
 
     def tick(self, *args, **kwargs):
         self.count += 1
+        return 16
 
 
 def make_view():

--- a/tests/test_memory_usage.py
+++ b/tests/test_memory_usage.py
@@ -19,7 +19,7 @@ class DummyFont:
 
 class DummyClock:
     def tick(self, *args, **kwargs):
-        pass
+        return 16
 
 
 def make_view():

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -25,6 +25,7 @@ class PerfClock:
         now = time.perf_counter()
         self.times.append(now - self.last)
         self.last = now
+        return int((self.times[-1]) * 1000)
 
 
 def make_view():

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -32,6 +32,7 @@ class DummyClock:
 
     def tick(self, *args, **kwargs):
         self.count += 1
+        return 16
 
 
 def make_view():


### PR DESCRIPTION
## Summary
- ensure DummyClock classes return an integer value from `tick`
- return elapsed ms in `PerfClock.tick`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867eef985548326a433314f8c593f9b