### PR TITLE
Fix flake8 F841 by removing unused duration vars

### DIFF
--- a/pygame_gui/animations.py
+++ b/pygame_gui/animations.py
@@ -57,7 +57,6 @@ class AnimationMixin:
         """Briefly scale ``sprites`` up then back down for a bounce effect."""
         if not sprites:
             return
-        duration = (frames / 60) / self.animation_speed
         originals = [(sp.image, sp.rect.copy()) for sp in sprites]
         steps = math.ceil(frames / self.animation_speed)
         half = max(1, steps // 2)
@@ -162,7 +161,6 @@ class AnimationMixin:
             rect.midleft = (x, y)
         else:
             rect.midright = (x, y)
-        duration = (frames / 60) / self.animation_speed
         steps = math.ceil(frames / self.animation_speed)
         for i in range(steps):
             progress = (i + 1) / steps


### PR DESCRIPTION
## Summary
- remove unused `duration` calculations in animation helpers

## Testing
- `flake8`
- `coverage run -m pytest`
- `coverage xml`


------
https://chatgpt.com/codex/tasks/task_e_686870c54f9883269aec9019f6e49409