### PR TITLE
Improve frame drawing control

### DIFF
--- a/pygame_gui/animations.py
+++ b/pygame_gui/animations.py
@@ -105,7 +105,7 @@ class AnimationMixin:
                 int(start[0] + (dest[0] - start[0]) * t),
                 int(start[1] + (dest[1] - start[1]) * t),
             )
-            self._draw_frame()
+            self._draw_frame(flip=False)
             self.screen.blit(img, rect)
             pygame.display.flip()
             pygame.event.pump()
@@ -135,7 +135,7 @@ class AnimationMixin:
                     int(sx + (dest[0] - sx) * t),
                     int(sy + (dest[1] - sy) * t),
                 )
-            self._draw_frame()
+            self._draw_frame(flip=False)
             for sp, front in zip(sprites, fronts):
                 img = back if back is not None and t < 0.5 else front
                 rect = img.get_rect(center=sp.rect.center)
@@ -164,7 +164,7 @@ class AnimationMixin:
         steps = math.ceil(frames / self.animation_speed)
         for i in range(steps):
             progress = (i + 1) / steps
-            self._draw_frame()
+            self._draw_frame(flip=False)
             overlay = pygame.Surface(rect.size, pygame.SRCALPHA)
             alpha = max(0, 200 - int(progress * 200))
             center = overlay.get_rect().center
@@ -205,7 +205,7 @@ class AnimationMixin:
         current = self.overlay
         # Draw the base screen once and reuse it during the animation
         self.overlay = None
-        self._draw_frame()
+        self._draw_frame(flip=False)
         base = self.screen.copy()
         self.overlay = current
         elapsed = 0.0

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -203,8 +203,16 @@ class GameView(AnimationMixin):
         self.show_menu()
 
     # Animation helpers -------------------------------------------------
-    def _draw_frame(self) -> None:
-        """Redraw the game state."""
+    def _draw_frame(self, flip: bool = True) -> None:
+        """Redraw the game state.
+
+        Parameters
+        ----------
+        flip:
+            If ``True`` (default), ``pygame.display.flip()`` is called after
+            drawing. Animation helpers can pass ``False`` to defer flipping until
+            additional elements are drawn.
+        """
         if self.state == GameState.MENU and self.main_menu_image:
             bg = pygame.transform.smoothscale(
                 self.main_menu_image, self.screen.get_size()
@@ -222,7 +230,8 @@ class GameView(AnimationMixin):
             self.screen.blit(overlay_surf, (0, 0))
             self.overlay.draw(self.screen)
         self.draw_score_overlay()
-        pygame.display.flip()
+        if flip:
+            pygame.display.flip()
 
     # Layout helpers --------------------------------------------------
     def _layout_zones(self) -> None:

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -41,7 +41,7 @@ def make_view():
                         view = pygame_gui.GameView(1, 1)
     # Ensure highlight_turn does not access the display during tests
     view._highlight_turn = lambda *a, **k: None
-    view._draw_frame = lambda: None
+    view._draw_frame = lambda *a, **k: None
     return view
 
 

--- a/tests/test_memory_usage.py
+++ b/tests/test_memory_usage.py
@@ -38,7 +38,7 @@ def make_view():
                         view = pygame_gui.GameView(1, 1)
     # Ensure highlight_turn does not access the display during tests
     view._highlight_turn = lambda *a, **k: None
-    view._draw_frame = lambda: None
+    view._draw_frame = lambda *a, **k: None
     return view
 
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -43,7 +43,7 @@ def make_view():
                     view = pygame_gui.GameView(1, 1)
     # Avoid GUI operations during tests
     view._highlight_turn = lambda *a, **k: None
-    view._draw_frame = lambda: None
+    view._draw_frame = lambda *a, **k: None
     return view, clock
 
 

--- a/tests/test_player_pos.py
+++ b/tests/test_player_pos.py
@@ -28,7 +28,7 @@ def make_view(width=200, height=200):
             with patch.object(pygame_gui, "load_card_images"):
                 view = pygame_gui.GameView(width, height)
     # Avoid GUI operations during tests
-    view._draw_frame = lambda: None
+    view._draw_frame = lambda *a, **k: None
     return view
 
 

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -48,7 +48,7 @@ def make_view():
             with patch.object(pygame_gui, "load_card_images"):
                 with patch("pygame.time.Clock", return_value=clock):
                     view = pygame_gui.GameView(1, 1)
-    view._draw_frame = lambda: None
+    view._draw_frame = lambda *a, **k: None
     return view, clock
 
 


### PR DESCRIPTION
## Summary
- allow `GameView._draw_frame()` to optionally skip calling `pygame.display.flip`
- update animations to defer flipping until after extra drawing
- adjust tests for new `_draw_frame` signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868769656d8832697e212dd14d5f53a