### PR TITLE
Optimize highlight surface usage

### DIFF
--- a/pygame_gui/animations.py
+++ b/pygame_gui/animations.py
@@ -191,14 +191,15 @@ class AnimationMixin:
             rect.midright = (x, y)
         total = duration / self.animation_speed
         elapsed = 0.0
+        overlay = pygame.Surface(rect.size, pygame.SRCALPHA)
+        center = overlay.get_rect().center
         dt = yield
         while elapsed < total:
             elapsed += dt
             progress = min(elapsed / total, 1.0)
             self._draw_frame(flip=False)
-            overlay = pygame.Surface(rect.size, pygame.SRCALPHA)
+            overlay.fill((0, 0, 0, 0))
             alpha = max(0, 200 - int(progress * 200))
-            center = overlay.get_rect().center
             radius = 11 + int(3 * math.sin(math.pi * progress))
             if hasattr(overlay, "get_width"):
                 pygame.draw.circle(

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -236,6 +236,8 @@ class GameView(AnimationMixin):
 
     def _start_animation(self, anim):
         """Prime and store ``anim`` to run during the main loop."""
+        if anim is None:
+            return
         try:
             next(anim)
         except StopIteration:

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -506,7 +506,7 @@ def test_highlight_turn_draws_at_player_position():
     view.screen = MagicMock()
     view.screen.get_size.return_value = (100, 100)
     overlay_surface = MagicMock()
-    with patch("pygame.Surface", return_value=overlay_surface), patch(
+    with patch("pygame.Surface", return_value=overlay_surface) as surf_mock, patch(
         "pygame.event.pump"
     ), patch("pygame.display.flip"), patch("pygame.draw.circle"), patch.object(
         view, "_player_pos", return_value=(50, 100)
@@ -521,6 +521,8 @@ def test_highlight_turn_draws_at_player_position():
     pos.assert_called_with(0)
     topleft = (50 - 70, 100 - 30)
     view.screen.blit.assert_called_with(overlay_surface, topleft)
+    assert surf_mock.call_count == 1
+    assert overlay_surface.fill.call_count == 2
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- create the highlight surface once and reuse it each frame
- guard `_start_animation` against `None` animations
- verify single surface creation in highlight tests

## Testing
- `pytest -q tests/test_pygame_gui.py::test_highlight_turn_draws_at_player_position tests/test_pygame_gui.py::test_highlight_turn_speed -vv`

------
https://chatgpt.com/codex/tasks/task_e_68687c9ae15083269f15b86c6f102e4c