### PR TITLE
Add master AI depth and Monte Carlo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ After installation launch the Pygame GUI with `tien-len` or start the CLI via `t
 To play in the terminal run:
 
 ```bash
-python3 tien_len_full.py [--ai Easy|Normal|Hard|Expert] \
+python3 tien_len_full.py [--ai Easy|Normal|Hard|Expert|Master] \
                         [--personality aggressive|defensive|balanced|random] \
-                        [--lookahead]
+                        [--lookahead] [--depth N]
 ```
 After installation the same game can be started with the `tien-len-cli` command.
 

--- a/pygame_gui/overlays.py
+++ b/pygame_gui/overlays.py
@@ -352,7 +352,7 @@ class GameSettingsOverlay(Overlay):
             btn.callback = cycle(attr, opts, label)(btn)
             self.buttons.append(btn)
 
-        make_button(0, "ai_level", ["Easy", "Normal", "Hard", "Expert"], "AI Level")
+        make_button(0, "ai_level", ["Easy", "Normal", "Hard", "Expert", "Master"], "AI Level")
         make_button(
             50,
             "ai_personality",
@@ -360,19 +360,20 @@ class GameSettingsOverlay(Overlay):
             "Personality",
         )
         make_button(100, "ai_lookahead", [False, True], "Lookahead")
-        make_button(150, "animation_speed", [0.5, 1.0, 2.0], "Anim Speed")
-        make_button(200, "sort_mode", ["rank", "suit"], "Sort Mode")
+        make_button(150, "ai_depth", [1, 2, 3], "AI Depth")
+        make_button(200, "animation_speed", [0.5, 1.0, 2.0], "Anim Speed")
+        make_button(250, "sort_mode", ["rank", "suit"], "Sort Mode")
         self.buttons.append(
             Button(
                 "House Rules",
-                pygame.Rect(bx, by + 250, 240, 40),
+                pygame.Rect(bx, by + 300, 240, 40),
                 lambda: self.view.show_rules(from_menu=False),
                 font,
             )
         )
         btn = Button(
             "Back",
-            pygame.Rect(bx, by + 300, 240, 40),
+            pygame.Rect(bx, by + 350, 240, 40),
             self.view.show_settings,
             font,
             **load_button_images("button_back"),

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -135,6 +135,7 @@ class GameView(AnimationMixin):
         self.ai_level = "Normal"
         self.ai_personality = "balanced"
         self.ai_lookahead = False
+        self.ai_depth = 1
         self.sort_mode = "rank"
         self.player_name = "Player"
         self.card_back_name = "card_back"
@@ -174,6 +175,7 @@ class GameView(AnimationMixin):
         self.ai_level = opts.get("ai_level", self.ai_level)
         self.ai_personality = opts.get("ai_personality", self.ai_personality)
         self.ai_lookahead = opts.get("ai_lookahead", self.ai_lookahead)
+        self.ai_depth = opts.get("ai_depth", self.ai_depth)
         self.sound_enabled = opts.get("sound", self.sound_enabled)
         self.music_enabled = opts.get("music", self.music_enabled)
         self.music_volume = opts.get("music_volume", self.music_volume)
@@ -636,6 +638,7 @@ class GameView(AnimationMixin):
             "ai_level": self.ai_level,
             "ai_personality": self.ai_personality,
             "ai_lookahead": self.ai_lookahead,
+            "ai_depth": self.ai_depth,
             "sound": self.sound_enabled,
             "music": self.music_enabled,
             "music_volume": self.music_volume,
@@ -683,6 +686,7 @@ class GameView(AnimationMixin):
         self.game.set_ai_level(self.ai_level)
         self.game.set_personality(self.ai_personality)
         self.game.ai_lookahead = self.ai_lookahead
+        self.game.ai_depth = self.ai_depth
         self.game.allow_2_in_sequence = not self.rule_no_2s
         self.game.flip_suit_rank = self.rule_flip_suit_rank
         sound.set_volume(self.fx_volume)

--- a/tests/test_cli_flags.py
+++ b/tests/test_cli_flags.py
@@ -12,13 +12,15 @@ def test_personality_and_lookahead_flags(monkeypatch):
         captured['ai'] = self.ai_level
         captured['personality'] = self.ai_personality
         captured['lookahead'] = self.ai_lookahead
+        captured['depth'] = self.ai_depth
 
     monkeypatch.setattr('tien_len_full.Game.play', fake_play)
-    run_cli(['--ai', 'Hard', '--personality', 'aggressive', '--lookahead'])
+    run_cli(['--ai', 'Hard', '--personality', 'aggressive', '--lookahead', '--depth', '2'])
     assert captured == {
         'ai': 'Hard',
         'personality': 'aggressive',
         'lookahead': True,
+        'depth': 2,
     }
 
 
@@ -29,6 +31,7 @@ def test_cli_defaults(monkeypatch):
         captured['ai'] = self.ai_level
         captured['personality'] = self.ai_personality
         captured['lookahead'] = self.ai_lookahead
+        captured['depth'] = self.ai_depth
 
     monkeypatch.setattr('tien_len_full.Game.play', fake_play)
     run_cli([])
@@ -36,4 +39,5 @@ def test_cli_defaults(monkeypatch):
         'ai': 'Normal',
         'personality': 'balanced',
         'lookahead': False,
+        'depth': 1,
     }

--- a/tests/test_expert_ai.py
+++ b/tests/test_expert_ai.py
@@ -17,6 +17,27 @@ def test_minimax_decision_selects_optimal_move():
     game.players[3].hand = []
     game.current_idx = 1
 
-    move = game._minimax_decision(ai)
+    move = game._minimax_decision(ai, 1)
     assert set(move) == {Card('Spades', '3'), Card('Hearts', '3')}
+
+
+def test_master_ai_sets_depth():
+    game = Game()
+    game.set_ai_level("Master")
+    assert game.ai_depth > 1
+
+
+def test_minimax_respects_depth_param():
+    game = Game()
+    ai = game.players[1]
+    ai.hand = [Card('Spades', '3'), Card('Hearts', '4')]
+    ai.sort_hand()
+    game.players[0].hand = []
+    game.players[2].hand = []
+    game.players[3].hand = []
+    game.current_idx = 1
+
+    move_short = game._minimax_decision(ai, 1)
+    move_deep = game._minimax_decision(ai, 2)
+    assert move_short == move_deep
 

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -750,6 +750,7 @@ def test_apply_options_updates_game_and_audio():
     view.ai_level = "Hard"
     view.ai_personality = "aggressive"
     view.ai_lookahead = True
+    view.ai_depth = 2
     view.fx_volume = 0.7
     view.music_volume = 0.5
     view.sound_enabled = True
@@ -773,6 +774,7 @@ def test_apply_options_updates_game_and_audio():
     sal.assert_called_with("Hard")
     sp.assert_called_with("aggressive")
     assert view.game.ai_lookahead is True
+    assert view.game.ai_depth == 2
     sv.assert_called_with(0.7)
     mv.assert_called_with(0.5)
     pause.assert_called_once()


### PR DESCRIPTION
## Summary
- expand AI settings with new `Master` level and depth control
- add Monte Carlo fallback in the minimax evaluator
- expose depth option via CLI and GUI
- test the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686936134a5c8326b5f66c150d92b601