### PR TITLE
Optimize sprite updates with RenderUpdates

### DIFF
--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -126,8 +126,8 @@ class GameView(AnimationMixin):
                 pass
         self.selected: List[CardSprite] = []
         self.current_trick: list[tuple[str, pygame.Surface]] = []
-        self.ai_sprites: List[pygame.sprite.Group] = [
-            pygame.sprite.Group() for _ in range(3)
+        self.ai_sprites: List[pygame.sprite.RenderUpdates] = [
+            pygame.sprite.RenderUpdates() for _ in range(3)
         ]
         self.running = True
         self.overlay: Optional[Overlay] = None
@@ -938,8 +938,8 @@ class GameView(AnimationMixin):
     def update_hand_sprites(self):
         """Create card sprites for all players with a simple table layout."""
 
-        self.hand_sprites = pygame.sprite.Group()
-        self.ai_sprites = [pygame.sprite.Group() for _ in range(3)]
+        self.hand_sprites = pygame.sprite.RenderUpdates()
+        self.ai_sprites = [pygame.sprite.RenderUpdates() for _ in range(3)]
 
         card_w = self.card_width
         card_h = int(card_w * 1.4)
@@ -1007,6 +1007,16 @@ class GameView(AnimationMixin):
         sprites = self.hand_sprites.sprites()
         card_h = sprites[0].rect.height if sprites else int(card_w * 1.4)
         spacing = min(40, card_w)
+
+        bg = self._table_surface
+        if bg is None:
+            bg = pygame.Surface(self.screen.get_size())
+            bg.fill(self.table_color)
+
+        # Clear previous sprite positions
+        self.hand_sprites.clear(self.screen, bg)
+        for group in self.ai_sprites:
+            group.clear(self.screen, bg)
 
         # Draw semi-transparent zones behind each player's hand
         for idx in range(len(self.game.players)):

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -112,7 +112,7 @@ def test_handle_mouse_select_and_overlay():
     view, _ = make_view()
     sprite = DummySprite()
     center = sprite.rect.center
-    view.hand_sprites = pygame.sprite.Group(sprite)
+    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
     view.selected = []
     view.state = pygame_gui.GameState.PLAYING
     view.action_buttons = []
@@ -138,7 +138,7 @@ def test_handle_mouse_selects_rightmost_sprite():
     view, _ = make_view()
     left = DummySprite((5, 5))
     right = DummySprite((5, 5))
-    view.hand_sprites = pygame.sprite.Group(left, right)
+    view.hand_sprites = pygame.sprite.RenderUpdates(left, right)
     view.selected = []
     view.state = pygame_gui.GameState.PLAYING
     view.action_buttons = []
@@ -180,7 +180,7 @@ def test_update_play_button_state_disables_when_invalid():
 def test_handle_mouse_calls_update_play_button_state():
     view, _ = make_view()
     sprite = DummyCardSprite((5, 5))
-    view.hand_sprites = pygame.sprite.Group(sprite)
+    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
     view.selected = []
     view.state = pygame_gui.GameState.PLAYING
     view.action_buttons = []
@@ -395,7 +395,7 @@ def test_draw_players_uses_draw_shadow():
             return_value=pygame.Surface((1, 1), pygame.SRCALPHA),
         ):
             sprite = pygame_gui.CardSprite(tien_len_full.Card("Spades", "3"), (0, 0), 1)
-    view.hand_sprites = pygame.sprite.Group(sprite)
+    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
     with patch.object(sprite, "draw_shadow") as ds:
         view.draw_players()
         ds.assert_called()
@@ -404,7 +404,7 @@ def test_draw_players_uses_draw_shadow():
 
 def test_draw_players_labels_use_padding():
     view, _ = make_view()
-    view.hand_sprites = pygame.sprite.Group()
+    view.hand_sprites = pygame.sprite.RenderUpdates()
     view.ai_sprites = []
     view.screen = MagicMock()
     view.screen.get_size.return_value = (200, 200)
@@ -439,8 +439,8 @@ def test_draw_players_labels_use_padding():
 
 def test_player_zone_rect_returns_union():
     view, _ = make_view()
-    view.hand_sprites = pygame.sprite.Group()
-    view.ai_sprites = [pygame.sprite.Group() for _ in range(3)]
+    view.hand_sprites = pygame.sprite.RenderUpdates()
+    view.ai_sprites = [pygame.sprite.RenderUpdates() for _ in range(3)]
     rects = [pygame.Rect(1, 2, 4, 5), pygame.Rect(4, 10, 2, 3)]
     sprites = [DummySprite() for _ in rects]
     for sp, r in zip(sprites, rects):
@@ -455,8 +455,8 @@ def test_draw_players_highlights_active_zone():
     view, _ = make_view()
     view.screen = MagicMock()
     view.screen.get_size.return_value = (100, 100)
-    view.hand_sprites = pygame.sprite.Group()
-    view.ai_sprites = [pygame.sprite.Group() for _ in range(3)]
+    view.hand_sprites = pygame.sprite.RenderUpdates()
+    view.ai_sprites = [pygame.sprite.RenderUpdates() for _ in range(3)]
     zone = pygame.Rect(0, 0, 10, 10)
     with patch.object(view, "_player_zone_rect", return_value=zone), patch.object(
         pygame_gui.view, "draw_glow"
@@ -1039,7 +1039,7 @@ def test_play_selected_triggers_flip():
     view, _ = make_view()
     sprite = DummyCardSprite()
     view.selected = [sprite]
-    view.hand_sprites = pygame.sprite.Group(sprite)
+    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
     dest = view._pile_center()
     with (
         patch.object(view.game, "is_valid", return_value=(True, "")),
@@ -1126,7 +1126,7 @@ def test_restart_game_clears_current_trick_immediately():
 
 def test_draw_players_displays_trick_linearly():
     view, _ = make_view()
-    view.hand_sprites = pygame.sprite.Group()
+    view.hand_sprites = pygame.sprite.RenderUpdates()
     view.ai_sprites = []
     surf1 = pygame.Surface((10, 20))
     surf2 = pygame.Surface((10, 20))


### PR DESCRIPTION
## Summary
- use `RenderUpdates` groups for players' cards
- clear and draw sprites with background surfaces for partial blits
- adjust GUI tests for `RenderUpdates` groups

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68697a566ef08326bd454a5087a7a5f2