### PR TITLE
Expose FPS limit option

### DIFF
--- a/pygame_gui/overlays.py
+++ b/pygame_gui/overlays.py
@@ -435,9 +435,10 @@ class GraphicsOverlay(Overlay):
         make_button(100, "table_texture_name", make_table_tex, "Table Tex")
         make_button(150, "colorblind_mode", [False, True], "Colorblind")
         make_button(200, "fullscreen", [False, True], "Fullscreen")
+        make_button(250, "fps_limit", [30, 60, 120], "FPS Limit")
         btn = Button(
             "Back",
-            pygame.Rect(bx, by + 250, 240, 40),
+            pygame.Rect(bx, by + 300, 240, 40),
             self.view.show_settings,
             font,
             **load_button_images("button_back"),

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -20,11 +20,14 @@ class PerfClock:
     def __init__(self):
         self.times = []
         self.last = time.perf_counter()
+        self.args = []
 
     def tick(self, *args, **kwargs):
         now = time.perf_counter()
         self.times.append(now - self.last)
         self.last = now
+        if args:
+            self.args.append(args[0])
         return int((self.times[-1]) * 1000)
 
 
@@ -63,5 +66,19 @@ def test_average_frame_time_below_threshold():
 
     avg = sum(clock.times) / len(clock.times)
     assert avg < 0.05
+    pygame.quit()
+
+
+def test_custom_fps_limit_passed_to_clock():
+    view, clock = make_view()
+    view.fps_limit = 30
+
+    with patch(
+        "pygame.event.get",
+        return_value=[pygame.event.Event(pygame.QUIT, {})],
+    ), patch("pygame.quit"):
+        view.run()
+
+    assert clock.args[0] == 30
     pygame.quit()
 

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -1422,6 +1422,7 @@ def test_options_persist_across_sessions(tmp_path):
         view.score_visible = False
         view.score_pos = (30, 40)
         view.win_counts["Player"] = 3
+        view.fps_limit = 30
         view._save_options()
         # create new view that loads from same options file
         new_view, _ = make_view()
@@ -1435,6 +1436,7 @@ def test_options_persist_across_sessions(tmp_path):
     assert new_view.score_visible is False
     assert new_view.score_pos == (30, 40)
     assert new_view.win_counts["Player"] == 3
+    assert new_view.fps_limit == 30
 
 
 def test_rules_overlay_toggles_update_state():


### PR DESCRIPTION
## Summary
- add `fps_limit` setting to GameView and expose it in GraphicsOverlay
- persist FPS preference in options.json
- update tests for saved options
- check that custom FPS limit is passed to the clock

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686987a2a5e883268709de021d88bd57