### PR TITLE
Add shake animation for invalid plays

### DIFF
--- a/pygame_gui/animations.py
+++ b/pygame_gui/animations.py
@@ -169,6 +169,30 @@ class AnimationMixin:
                 break
             dt = yield
 
+    def _animate_shake(
+        self,
+        sprites: List[CardSprite],
+        amplitude: int = 5,
+        cycles: int = 3,
+        duration: float = 0.25,
+    ):
+        """Yield a horizontal shake animation for ``sprites``."""
+        if not sprites:
+            return
+        starts = [sp.rect.center for sp in sprites]
+        total = duration / self.animation_speed
+        elapsed = 0.0
+        dt = yield
+        while elapsed < total:
+            elapsed += dt
+            t = min(elapsed / total, 1.0)
+            offset = int(math.sin(t * cycles * 2 * math.pi) * amplitude)
+            for sp, (sx, sy) in zip(sprites, starts):
+                sp.rect.centerx = sx + offset
+            dt = yield
+        for sp, (sx, sy) in zip(sprites, starts):
+            sp.rect.centerx = sx
+
     def _highlight_turn(self, idx: int, duration: float = 10 / 60):
         """Yield an animation highlighting the active player."""
         x, y = self._player_pos(idx)

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -867,6 +867,7 @@ class GameView(AnimationMixin):
         player = self.game.players[self.game.current_idx]
         ok, msg = self.game.is_valid(player, cards, self.game.current_combo)
         if not ok:
+            self._start_animation(self._animate_shake(list(self.selected)))
             logger.info("Invalid: %s", msg)
             return
         if self.game.process_play(player, cards):
@@ -893,6 +894,7 @@ class GameView(AnimationMixin):
         if self.game.handle_pass():
             self.running = False
         else:
+            self._start_animation(self._animate_shake(list(self.selected)))
             sound.play("pass")
             self._start_animation(self._highlight_turn(self.game.current_idx))
             self.ai_turns()

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -1056,6 +1056,36 @@ def test_play_selected_triggers_flip():
     pygame.quit()
 
 
+def test_play_selected_shakes_on_invalid():
+    view, _ = make_view()
+    sprite = DummyCardSprite()
+    view.selected = [sprite]
+    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
+    with (
+        patch.object(view.game, "is_valid", return_value=(False, "bad")),
+        patch.object(view, "_animate_shake", return_value="gen") as shake,
+        patch.object(view, "_start_animation") as start,
+    ):
+        view.play_selected()
+    shake.assert_called_once_with([sprite])
+    start.assert_called_once_with("gen")
+
+
+def test_pass_turn_shakes_on_invalid():
+    view, _ = make_view()
+    with (
+        patch.object(view.game, "handle_pass", return_value=False),
+        patch.object(view, "_animate_shake", return_value="gen") as shake,
+        patch.object(view, "_start_animation") as start,
+        patch.object(sound, "play"),
+        patch.object(view, "_highlight_turn"),
+        patch.object(view, "ai_turns"),
+    ):
+        view.pass_turn()
+    shake.assert_called_once_with(list(view.selected))
+    assert start.call_args_list[0].args[0] == "gen"
+
+
 def test_draw_score_overlay_positions_panel():
     with patch("random.sample", return_value=tien_len_full.AI_NAMES[:3]):
         view, _ = make_view()


### PR DESCRIPTION
## Summary
- implement `_animate_shake` helper
- expose shake animation when an invalid selection or pass occurs
- test that shake animation runs on invalid input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869924908648326a9ec5b35c5c7dd43