### PR TITLE
Add animated card dealing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ are handled automatically.
 ### Pygame GUI features
 
 - Sprite-based interface with simple animations.
+- Animated card dealing at the start of each game.
 - Press **F11** to toggle full-screen.
 - Sprites and layout adapt automatically when the window is resized.
 - Press **Enter** or **Space** for the usual shortcuts.

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -204,6 +204,7 @@ class GameView(AnimationMixin):
             self.toggle_fullscreen()
         self.apply_options()
         self.update_hand_sprites()
+        self._start_animation(self._animate_deal())
         self._create_action_buttons()
         self.show_menu()
 
@@ -574,6 +575,8 @@ class GameView(AnimationMixin):
         self.selected.clear()
         self.current_trick.clear()
         self.apply_options()
+        self.update_hand_sprites()
+        self._start_animation(self._animate_deal())
         for p in self.game.players:
             counts.setdefault(p.name, 0)
         self.win_counts = counts


### PR DESCRIPTION
## Summary
- animate dealing cards one by one from the deck
- start card dealing animation after hands are built
- test the dealing animation and integration points
- mention animated dealing in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869975d615c8326a9d564c72584d0de