### PR TITLE
Add fade out for pile resets

### DIFF
--- a/pygame_gui/animations.py
+++ b/pygame_gui/animations.py
@@ -118,6 +118,29 @@ class AnimationMixin:
             self.screen.blit(dummy.image, dummy.rect)
             dt = yield
 
+    def _animate_fade_out(
+        self,
+        sprites: List[types.SimpleNamespace],
+        duration: float = 0.25,
+    ):
+        """Yield a fade-out animation for ``sprites``."""
+        if not sprites:
+            return
+        originals = [sp.image for sp in sprites]
+        rects = [sp.rect.copy() for sp in sprites]
+        total = duration / self.animation_speed
+        elapsed = 0.0
+        dt = yield
+        while elapsed < total:
+            elapsed += dt
+            progress = min(elapsed / total, 1.0)
+            alpha = max(0, 255 - int(progress * 255))
+            for img, rect in zip(originals, rects):
+                surf = img.copy()
+                surf.set_alpha(alpha)
+                self.screen.blit(surf, rect)
+            dt = yield
+
     def _animate_flip(
         self,
         sprites: List[CardSprite],

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -1230,7 +1230,9 @@ def test_current_trick_reset_on_restart_and_new_round():
     assert view.current_trick == []
 
     view.current_trick.append(("P1", pygame.Surface((1, 1))))
-    view.game.reset_pile()
+    with patch.object(view, "_animate_fade_out", return_value="gen") as fade, patch.object(view, "_start_animation") as start:
+        view.game.reset_pile()
+    start.assert_any_call("gen")
     assert view.current_trick == []
     pygame.quit()
 


### PR DESCRIPTION
## Summary
- implement `_animate_fade_out` for fading sprites
- fade current trick when pile resets
- patch tests to expect fade animation during pile reset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68699f68ccdc8326b3b94e13c3dffcbe