### PR TITLE
Include tests in flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,3 @@
 [flake8]
 max-line-length = 120
 extend-ignore = E203,W503
-exclude = tests/*

--- a/pygame_gui/animations.py
+++ b/pygame_gui/animations.py
@@ -6,7 +6,7 @@ from typing import List, Tuple, Optional
 
 import pygame
 
-from .helpers import CardSprite
+from .helpers import CardSprite, calc_start_and_overlap
 from .overlays import Overlay
 
 
@@ -447,4 +447,3 @@ class AnimationMixin:
                 surf.set_alpha(alpha)
                 self.screen.blit(surf, sp.rect)
             dt = yield
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,5 @@ assets = ["**/*"]
 [tool.flake8]
 max-line-length = 120
 extend-ignore = ["E203", "W503"]
-exclude = ["tests/*"]
 
 

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -1,11 +1,12 @@
-import pytest
-pytest.importorskip("pygame")
-
 import os
 from unittest.mock import patch
 
-import pygame
-import pygame_gui
+import pytest
+
+pytest.importorskip("pygame")
+
+import pygame  # noqa: E402
+import pygame_gui  # noqa: E402
 
 # Use dummy video driver so no window is opened
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')

--- a/tests/test_expert_ai.py
+++ b/tests/test_expert_ai.py
@@ -3,7 +3,7 @@ import pytest
 pytest.importorskip("pygame")
 pytest.importorskip("pygame_gui")
 
-from tien_len_full import Game, Card
+from tien_len_full import Game, Card  # noqa: E402
 
 
 def test_minimax_decision_selects_optimal_move():
@@ -40,4 +40,3 @@ def test_minimax_respects_depth_param():
     move_short = game._minimax_decision(ai, 1)
     move_deep = game._minimax_decision(ai, 2)
     assert move_short == move_deep
-

--- a/tests/test_get_font.py
+++ b/tests/test_get_font.py
@@ -1,8 +1,10 @@
 import pytest
+
 pytest.importorskip("pygame")
 
-import pygame
-import pygame_gui
+import pygame  # noqa: E402
+import pygame_gui  # noqa: E402
+
 
 class DummyFont:
     def render(self, *args, **kwargs):

--- a/tests/test_hint.py
+++ b/tests/test_hint.py
@@ -31,4 +31,3 @@ def test_hint_ignores_ai_difficulty():
 
     hint = game.hint(None)
     assert set(hint) == {c1, c2}
-

--- a/tests/test_json_serialization.py
+++ b/tests/test_json_serialization.py
@@ -1,5 +1,4 @@
 import json
-import pytest
 from unittest.mock import patch
 from tien_len_full import Game, Card, AI_NAMES
 

--- a/tests/test_memory_usage.py
+++ b/tests/test_memory_usage.py
@@ -1,12 +1,13 @@
 import os
-import pytest
-pytest.importorskip("pygame")
-
 import tracemalloc
 from unittest.mock import patch
 
-import pygame
-import pygame_gui
+import pytest
+
+pytest.importorskip("pygame")
+
+import pygame  # noqa: E402
+import pygame_gui  # noqa: E402
 
 # Use dummy video driver so no window is opened
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,11 +1,13 @@
 import os
 import time
+from unittest.mock import patch
+
 import pytest
+
 pytest.importorskip("pygame")
 
-import pygame
-import pygame_gui
-from unittest.mock import patch
+import pygame  # noqa: E402
+import pygame_gui  # noqa: E402
 
 # Use dummy video driver so no window is opened
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
@@ -81,4 +83,3 @@ def test_custom_fps_limit_passed_to_clock():
 
     assert clock.args[0] == 30
     pygame.quit()
-

--- a/tests/test_personality_volume.py
+++ b/tests/test_personality_volume.py
@@ -50,6 +50,7 @@ def test_ai_play_random_personality_uses_random_choice(monkeypatch):
 
     monkeypatch.setattr(game, 'generate_valid_moves', lambda p, c: [ai.hand])
     chosen = ['chosen']
+
     def fake_choice(seq):
         assert seq == [ai.hand]
         return chosen

--- a/tests/test_player_pos.py
+++ b/tests/test_player_pos.py
@@ -1,15 +1,16 @@
+import os
+from unittest.mock import patch
+
 import pytest
 
 pytest.importorskip("pygame")
 
-import os
-from unittest.mock import patch
-
-import pygame
-import pygame_gui
+import pygame  # noqa: E402
+import pygame_gui  # noqa: E402
 
 # Use dummy video driver so no window is opened
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
 
 class DummyFont:
     def render(self, *args, **kwargs):

--- a/tests/test_pygame_gui.py
+++ b/tests/test_pygame_gui.py
@@ -1,21 +1,20 @@
-import pytest
-
-pytest.importorskip("PIL")
-pytest.importorskip("pygame")
-
 import os
 import logging
 import math
 from unittest.mock import patch, MagicMock
 from pathlib import Path
+import pytest
+
+pytest.importorskip("PIL")
+pytest.importorskip("pygame")
 
 # Use dummy video driver so no window is opened
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
 
-import pygame
-import pygame_gui
-import tien_len_full
-import sound
+import pygame  # noqa: E402
+import pygame_gui  # noqa: E402
+import tien_len_full  # noqa: E402
+import sound  # noqa: E402
 
 
 class DummyFont:
@@ -1360,9 +1359,9 @@ def test_current_trick_reset_on_restart_and_new_round():
     assert view.current_trick == []
 
     view.current_trick.append(("P1", pygame.Surface((1, 1))))
-    with patch.object(view, "_animate_fade_out", return_value="gen") as fade, patch.object(
+    with patch.object(view, "_animate_fade_out", return_value="gen") as _, patch.object(
         view, "_animate_trick_clear", return_value="clear"
-    ) as clear, patch.object(view, "_start_animation") as start:
+    ) as _, patch.object(view, "_start_animation") as start:
         view.game.reset_pile()
     start_calls = [c.args[0] for c in start.call_args_list]
     assert "gen" in start_calls
@@ -1492,7 +1491,6 @@ def test_overlay_keyboard_navigation(cls, args):
     overlay.handle_event(pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_ESCAPE}))
     overlay.back_callback.assert_called_once()
     pygame.quit()
-
 
 
 def test_in_game_menu_buttons():
@@ -1753,7 +1751,6 @@ def test_profile_overlay_new_profile_added():
     assert set(view.win_counts) - existing
 
 
-
 def test_handle_score_event_dragging():
     view, _ = make_view()
     view.score_visible = True
@@ -1818,4 +1815,3 @@ def test_load_game_warning_on_oserror(tmp_path, caplog):
     assert "Failed to load game" in caplog.text
     assert view.game.to_dict() == before
     pygame.quit()
-

--- a/tests/test_round_summary.py
+++ b/tests/test_round_summary.py
@@ -25,4 +25,3 @@ def test_summary_round_logs_winner_and_next_starter(caplog):
     messages = [rec.message for rec in caplog.records]
     assert any(f"{winner.name} won the round" in m for m in messages)
     assert any(f"{winner.name} will start the next round" in m for m in messages)
-

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -71,8 +71,6 @@ def test_player_sort_and_bombs():
 
 
 def test_is_valid_basic_rules():
-    import tien_len_full as tl
-
     game = Game(flip_suit_rank=False)
     starter = game.players[0]
     game.current_idx = 0
@@ -116,7 +114,6 @@ def test_is_valid_basic_rules():
     assert ok
 
 
-
 def test_is_valid_first_card_flip_suit():
     import tien_len_full as tl
 
@@ -132,6 +129,7 @@ def test_is_valid_first_card_flip_suit():
     card3h = tl.Card('Hearts', '3')
     ok, msg = tl_game.is_valid(starter, [card3h], None)
     assert ok
+
 
 def test_flip_suit_rank_sorting_and_deck_order():
     import tien_len_full as tl

--- a/tests/test_sound.py
+++ b/tests/test_sound.py
@@ -90,7 +90,6 @@ def test_play_handles_errors():
     mock_sound.play.assert_called_once()
 
 
-
 def test_load_handles_sound_error(tmp_path):
     wav = tmp_path / "err.wav"
     wav.write_text("data")
@@ -101,4 +100,3 @@ def test_load_handles_sound_error(tmp_path):
             sound._SOUNDS.clear()
             assert not sound.load("bad", wav)
             assert "bad" not in sound._SOUNDS
-


### PR DESCRIPTION
## Summary
- run flake8 over the test suite
- update pyproject to no longer exclude tests
- fix lint in pygame_gui animations code
- clean up test files for flake8

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ab7a0888832685f6e359070e37ca