### PR TITLE
Fix import order and remove unused imports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -53,7 +53,6 @@ if pygame:
         def toggle(self):
             self.selected = not self.selected
 
-
     class DummyCardSprite(DummySprite):
         def __init__(self, pos=(0, 0)):
             super().__init__(pos)
@@ -68,7 +67,6 @@ else:  # pragma: no cover - pygame missing
 
         def toggle(self):
             self.selected = not self.selected
-
 
     class DummyCardSprite(DummySprite):
         def __init__(self, pos=(0, 0)):

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -1,12 +1,10 @@
 import os
 from unittest.mock import patch
-
 import pytest
+import pygame
+import pygame_gui
 
 pytest.importorskip("pygame")
-
-import pygame  # noqa: E402
-import pygame_gui  # noqa: E402
 
 # Use dummy video driver so no window is opened
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')

--- a/tests/test_expert_ai.py
+++ b/tests/test_expert_ai.py
@@ -1,9 +1,8 @@
 import pytest
+from tien_len_full import Game, Card
 
 pytest.importorskip("pygame")
 pytest.importorskip("pygame_gui")
-
-from tien_len_full import Game, Card  # noqa: E402
 
 
 def test_minimax_decision_selects_optimal_move():

--- a/tests/test_get_font.py
+++ b/tests/test_get_font.py
@@ -1,9 +1,8 @@
 import pytest
+import pygame
+import pygame_gui
 
 pytest.importorskip("pygame")
-
-import pygame  # noqa: E402
-import pygame_gui  # noqa: E402
 
 
 class DummyFont:

--- a/tests/test_gui_animations.py
+++ b/tests/test_gui_animations.py
@@ -3,17 +3,15 @@ import math
 from unittest.mock import patch, MagicMock
 from pathlib import Path
 import pytest
+import pygame
+import pygame_gui
+import tien_len_full
+from conftest import make_view, DummyFont, DummySprite, DummyCardSprite
 
 pytest.importorskip("PIL")
 pytest.importorskip("pygame")
 
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
-
-import pygame  # noqa: E402
-import pygame_gui  # noqa: E402
-import tien_len_full  # noqa: E402
-from conftest import make_view, DummyFont, DummySprite, DummyCardSprite
-
 
 
 def test_card_sprite_draw_shadow_blits():
@@ -530,5 +528,3 @@ def test_state_transitions():
         mock.assert_not_called()
     assert view.state == pygame_gui.GameState.GAME_OVER
     pygame.quit()
-
-

--- a/tests/test_gui_input.py
+++ b/tests/test_gui_input.py
@@ -1,16 +1,15 @@
 import os
 from unittest.mock import patch, MagicMock
 import pytest
+import pygame
+import pygame_gui
+from conftest import make_view, DummySprite, DummyCardSprite
 
 pytest.importorskip("PIL")
 pytest.importorskip("pygame")
 
 # Use dummy video driver so no window is opened
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
-
-import pygame  # noqa: E402
-import pygame_gui  # noqa: E402
-from conftest import make_view, DummySprite, DummyCardSprite
 
 
 def test_handle_key_shortcuts():

--- a/tests/test_gui_overlays.py
+++ b/tests/test_gui_overlays.py
@@ -1,19 +1,17 @@
 import os
 import logging
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 import pytest
+import pygame
+import pygame_gui
+import tien_len_full
+import sound
+from conftest import make_view, DummyFont, DummyCardSprite
 
 pytest.importorskip("PIL")
 pytest.importorskip("pygame")
 
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
-
-import pygame  # noqa: E402
-import pygame_gui  # noqa: E402
-import tien_len_full  # noqa: E402
-import sound  # noqa: E402
-from conftest import make_view, DummyFont, DummySprite, DummyCardSprite
 
 
 def test_on_resize_rebuilds_sprites():

--- a/tests/test_memory_usage.py
+++ b/tests/test_memory_usage.py
@@ -1,13 +1,11 @@
 import os
 import tracemalloc
 from unittest.mock import patch
-
 import pytest
+import pygame
+import pygame_gui
 
 pytest.importorskip("pygame")
-
-import pygame  # noqa: E402
-import pygame_gui  # noqa: E402
 
 # Use dummy video driver so no window is opened
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,13 +1,11 @@
 import os
 import time
 from unittest.mock import patch
-
 import pytest
+import pygame
+import pygame_gui
 
 pytest.importorskip("pygame")
-
-import pygame  # noqa: E402
-import pygame_gui  # noqa: E402
 
 # Use dummy video driver so no window is opened
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")

--- a/tests/test_player_pos.py
+++ b/tests/test_player_pos.py
@@ -1,12 +1,10 @@
 import os
 from unittest.mock import patch
-
 import pytest
+import pygame
+import pygame_gui
 
 pytest.importorskip("pygame")
-
-import pygame  # noqa: E402
-import pygame_gui  # noqa: E402
 
 # Use dummy video driver so no window is opened
 os.environ.setdefault("SDL_VIDEODRIVER", "dummy")


### PR DESCRIPTION
## Summary
- reorder imports so they're at the top of each module
- remove unused `DummySprite` and `pathlib.Path` imports
- keep `pytest.importorskip` and environment tweaks after imports

## Testing
- `flake8`
- `pytest -k bomb_reveal_draws_flash -q` *(fails on full test suite: `tests/test_gui_animations.py::test_bomb_reveal_draws_flash`)*

------
https://chatgpt.com/codex/tasks/task_e_6869d3c54ed48326bd5eb4b2bb311632