### PR TITLE
Reset scores on game restart

### DIFF
--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -568,20 +568,21 @@ class GameView(AnimationMixin):
         self.running = False
 
     def restart_game(self) -> None:
-        counts = self.win_counts
         self.game = Game()
         self.game.setup()
         self._attach_reset_pile()
+        self.reset_scores()
         self.reset_current_trick()
         self.selected.clear()
         self.current_trick.clear()
         self.apply_options()
         self.update_hand_sprites()
         self._start_animation(self._animate_deal())
-        for p in self.game.players:
-            counts.setdefault(p.name, 0)
-        self.win_counts = counts
         self.close_overlay()
+
+    def reset_scores(self) -> None:
+        """Reset player win counts."""
+        self.win_counts = {p.name: 0 for p in self.game.players}
 
     def reset_current_trick(self, animate: bool = True) -> None:
         """Clear the list of cards representing the current trick."""

--- a/tests/test_gui_overlays.py
+++ b/tests/test_gui_overlays.py
@@ -599,7 +599,7 @@ def test_show_game_over_updates_win_counts():
     pygame.quit()
 
 
-def test_restart_game_preserves_scores():
+def test_restart_game_resets_scores():
     with patch("random.sample", return_value=tien_len_full.AI_NAMES[:3]):
         view, _ = make_view()
     view.win_counts["Player"] = 2
@@ -607,9 +607,8 @@ def test_restart_game_preserves_scores():
         view, "close_overlay"
     ):
         view.restart_game()
-    assert view.win_counts["Player"] == 2
     for p in view.game.players:
-        assert p.name in view.win_counts
+        assert view.win_counts[p.name] == 0
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- add a `reset_scores` helper to `GameView`
- call it from `restart_game`
- update overlay test for score reset behaviour

## Testing
- `pytest tests/test_gui_overlays.py::test_restart_game_resets_scores tests/test_gui_overlays.py::test_restart_game_triggers_deal_animation tests/test_gui_overlays.py::test_restart_game_clears_current_trick_immediately -q`
- `pytest tests/test_gui_overlays.py::test_current_trick_reset_on_restart_and_new_round -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_686a62e18ef883269b0bd5969c42288f