### PR TITLE
Clamp score panel position

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -89,6 +89,8 @@ def make_view(width=1, height=1, clock=None):
     pygame.init()
     pygame.font.init()
     pygame.display.init()
+    if pygame.display.get_surface() is None:
+        pygame.display.set_mode((width, height))
     pygame_gui.clear_font_cache()
     clk = clock or DummyClock()
     with patch("pygame.display.set_mode", return_value=pygame.Surface((width, height))):

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -457,6 +457,16 @@ class GameView(AnimationMixin):
             self.score_button.callback = self.toggle_score
         self.score_button.rect.topleft = (5, 5)
 
+    def _clamp_score_pos(self) -> None:
+        """Ensure the score panel stays within the window bounds."""
+        w, h = self.screen.get_size()
+        max_x = max(0, w - self.score_rect.width)
+        max_y = max(0, h - self.score_rect.height)
+        x = min(max(self.score_pos[0], 0), max_x)
+        y = min(max(self.score_pos[1], 0), max_y)
+        self.score_pos = (x, y)
+        self.score_rect.topleft = self.score_pos
+
     def toggle_score(self) -> None:
         """Toggle visibility of the score panel and save."""
         self.score_visible = not self.score_visible
@@ -774,6 +784,7 @@ class GameView(AnimationMixin):
         self.update_hand_sprites()
         self._create_action_buttons()
         self._position_score_button()
+        self._clamp_score_pos()
         self._position_settings_button()
         if self.overlay:
             self.overlay.resize()
@@ -1211,6 +1222,7 @@ class GameView(AnimationMixin):
         elif event.type == pygame.MOUSEBUTTONUP:
             if self._dragging_score:
                 self._dragging_score = False
+                self._clamp_score_pos()
                 self._save_options()
                 return True
         elif event.type == pygame.MOUSEMOTION and self._dragging_score:

--- a/tests/test_gui_overlays.py
+++ b/tests/test_gui_overlays.py
@@ -130,6 +130,21 @@ def test_on_resize_calls_create_action_buttons():
         create.assert_called_once()
 
 
+def test_on_resize_clamps_score_pos():
+    view, _ = make_view()
+    with patch(
+        "pygame.display.set_mode", return_value=pygame.Surface((1, 1))
+    ), patch.object(pygame_gui, "load_card_images"), patch.object(
+        view, "update_hand_sprites"
+    ), patch.object(view, "_create_action_buttons"), patch.object(
+        view, "_position_score_button"
+    ), patch.object(
+        view, "_position_settings_button"
+    ), patch.object(view, "_clamp_score_pos") as clamp:
+        view.on_resize(100, 100)
+    clamp.assert_called_once()
+
+
 def test_apply_options_updates_game_and_audio():
     view, _ = make_view()
     p0 = view.game.players[0]
@@ -1033,7 +1048,9 @@ def test_handle_score_event_dragging():
     view.score_pos = (50, 10)
     view.draw_score_overlay()
     start_x, start_y = view.score_pos
-    with patch.object(view, "_save_options") as save:
+    with patch.object(view, "_save_options") as save, patch.object(
+        view, "_clamp_score_pos"
+    ) as clamp:
         down = pygame.event.Event(
             pygame.MOUSEBUTTONDOWN, {"pos": (start_x + 5, start_y + 5)}
         )
@@ -1048,6 +1065,7 @@ def test_handle_score_event_dragging():
         )
         assert view._handle_score_event(up) is True
         save.assert_called_once()
+        clamp.assert_called_once()
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- keep score panel inside the window via `_clamp_score_pos`
- clamp score position on resize and after dragging
- tests cover resize clamping and drag handling
- ensure a display surface exists for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a659c96a483269520a4d5c76381c5