### PR TITLE
Add bundled font loading and tests

### DIFF
--- a/pygame_gui/helpers.py
+++ b/pygame_gui/helpers.py
@@ -13,6 +13,8 @@ from tien_len_full import Card
 
 # Path to the installed assets directory
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "assets"
+# Path to the bundled TTF font shipped with the package
+FONT_FILE = ASSETS_DIR / "fonts" / "DejaVuSans.ttf"
 
 LOG_FILE = "tien_len_game.log"
 
@@ -46,7 +48,14 @@ def get_font(size: int) -> pygame.font.Font:
         _FONT_CACHE.clear()
 
     if size not in _FONT_CACHE:
-        _FONT_CACHE[size] = pygame.font.SysFont(None, size)
+        # Use bundled font when available to ensure consistent appearance
+        if FONT_FILE.is_file():
+            try:
+                _FONT_CACHE[size] = pygame.font.Font(str(FONT_FILE), size)
+            except Exception:  # pragma: no cover - fall back if font load fails
+                _FONT_CACHE[size] = pygame.font.SysFont(None, size)
+        else:
+            _FONT_CACHE[size] = pygame.font.SysFont(None, size)
     return _FONT_CACHE[size]
 
 


### PR DESCRIPTION
## Summary
- reference bundled font with constant `FONT_FILE`
- load bundled font in `helpers.get_font` with fallback to `SysFont`
- extend tests for font loading and reinitialisation
- remove `DejaVuSans.ttf` from repository

## Testing
- `pytest tests/test_get_font.py -q`
- `pytest -k get_font -q`


------
https://chatgpt.com/codex/tasks/task_e_686a5f5865688326804ea20a76433b26