### PR TITLE
Add pip caching in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,20 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
+        env:
+          PIP_CACHE_DIR: ~/.cache/pip
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install flake8
+          pip install --cache-dir "$PIP_CACHE_DIR" -r requirements.txt
+          pip install --cache-dir "$PIP_CACHE_DIR" flake8
       - name: Run flake8
         run: |
           flake8


### PR DESCRIPTION
## Summary
- cache pip downloads in CI
- use cached pip dir when installing dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a7640a59c8326881c3fa9391a1d1f