### PR TITLE
Add PASS text animation

### DIFF
--- a/pygame_gui/animations.py
+++ b/pygame_gui/animations.py
@@ -253,6 +253,30 @@ class AnimationMixin:
             self.screen.blit(overlay, rect.topleft)
             dt = yield
 
+    def _animate_pass_text(self, idx: int, duration: float = 0.5):
+        """Yield an animation showing "PASS" over ``idx``'s zone."""
+        zone = self._player_zone_rect(idx)
+        if zone.width <= 0 or zone.height <= 0:
+            return
+        panel = self._hud_box(["PASS"], bg_image=self.panel_image)
+        rect = panel.get_rect(center=zone.center)
+        start = rect.center
+        dest = (rect.centerx, rect.centery - 30)
+        total = duration / self.animation_speed
+        elapsed = 0.0
+        dt = yield
+        while elapsed < total:
+            elapsed += dt
+            t = ease(min(elapsed / total, 1.0))
+            rect.center = (
+                int(start[0] + (dest[0] - start[0]) * t),
+                int(start[1] + (dest[1] - start[1]) * t),
+            )
+            surf = panel.copy()
+            surf.set_alpha(max(0, 255 - int(t * 255)))
+            self.screen.blit(surf, rect)
+            dt = yield
+
     def _transition_overlay(
         self,
         old: Optional[Overlay],

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -940,6 +940,9 @@ class GameView(AnimationMixin):
         else:
             self._start_animation(self._animate_shake(list(self.selected)))
             sound.play("pass")
+            self._start_animation(
+                self._animate_pass_text(self.game.current_idx)
+            )
             self._start_animation(self._highlight_turn(self.game.current_idx))
             self.ai_turns()
         if not self.game.pile:
@@ -999,6 +1002,9 @@ class GameView(AnimationMixin):
             else:
                 sound.play("pass")
                 self.game.process_pass(p)
+                self._start_animation(
+                    self._animate_pass_text(self.game.current_idx)
+                )
             self.game.next_turn()
             self._start_animation(self._highlight_turn(self.game.current_idx))
             if not self.game.pile:

--- a/tests/test_gui_animations.py
+++ b/tests/test_gui_animations.py
@@ -405,6 +405,26 @@ def test_highlight_turn_draws_at_player_position():
     pygame.quit()
 
 
+def test_animate_pass_text_draws_panel():
+    view, _ = make_view()
+    view.screen = MagicMock()
+    zone = pygame.Rect(0, 0, 10, 10)
+    panel = pygame.Surface((2, 2))
+    with patch.object(view, "_player_zone_rect", return_value=zone) as rect_mock, patch.object(
+        view, "_hud_box", return_value=panel
+    ) as hud, patch("pygame.event.pump"), patch("pygame.display.flip"):
+        gen = view._animate_pass_text(1, duration=2 / 60)
+        next(gen)
+        gen.send(1 / 60)
+        try:
+            gen.send(1 / 60)
+        except StopIteration:
+            pass
+    rect_mock.assert_called_with(1)
+    hud.assert_called_once()
+    assert view.screen.blit.call_count >= 1
+    
+
 def test_state_methods_update_state():
     view, _ = make_view()
     assert view.state == pygame_gui.GameState.MENU


### PR DESCRIPTION
## Summary
- animate PASS text above a player's zone
- trigger PASS animation for human and AI players
- test the new animation call points

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_686a84d5a2a083268fb0bd6cb979fb0d