### PR TITLE
Add avatar blink animation

### DIFF
--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -932,6 +932,7 @@ class GameView(AnimationMixin):
         self.selected.clear()
         self.update_hand_sprites()
         self._start_animation(self._highlight_turn(self.game.current_idx))
+        self._start_animation(self._animate_avatar_blink(self.game.current_idx))
         self.ai_turns()
 
     def pass_turn(self):
@@ -944,6 +945,7 @@ class GameView(AnimationMixin):
                 self._animate_pass_text(self.game.current_idx)
             )
             self._start_animation(self._highlight_turn(self.game.current_idx))
+            self._start_animation(self._animate_avatar_blink(self.game.current_idx))
             self.ai_turns()
         if not self.game.pile:
             self.current_trick.clear()
@@ -1007,10 +1009,12 @@ class GameView(AnimationMixin):
                 )
             self.game.next_turn()
             self._start_animation(self._highlight_turn(self.game.current_idx))
+            self._start_animation(self._animate_avatar_blink(self.game.current_idx))
             if not self.game.pile:
                 self.current_trick.clear()
         self.update_hand_sprites()
         self._start_animation(self._highlight_turn(self.game.current_idx))
+        self._start_animation(self._animate_avatar_blink(self.game.current_idx))
 
     # Rendering -------------------------------------------------------
     def update_hand_sprites(self):
@@ -1242,6 +1246,7 @@ class GameView(AnimationMixin):
     def run(self):
         self.update_hand_sprites()
         self._start_animation(self._highlight_turn(self.game.current_idx))
+        self._start_animation(self._animate_avatar_blink(self.game.current_idx))
         while self.running:
             dt = self.clock.tick(self.fps_limit) / 1000.0
             self.dt = dt

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -36,10 +36,12 @@ def make_view():
         ):
             with patch.object(pygame_gui, 'load_card_images'):
                 with patch('pygame.time.Clock', return_value=clock):
-                    with patch.object(pygame_gui.GameView, '_highlight_turn'):
+                    with patch.object(pygame_gui.GameView, '_highlight_turn'), \
+                         patch.object(pygame_gui.GameView, '_animate_avatar_blink'):
                         view = pygame_gui.GameView(1, 1)
     # Ensure highlight_turn does not access the display during tests
     view._highlight_turn = lambda *a, **k: None
+    view._animate_avatar_blink = lambda *a, **k: None
     view._draw_frame = lambda *a, **k: None
     return view
 

--- a/tests/test_gui_input.py
+++ b/tests/test_gui_input.py
@@ -70,7 +70,7 @@ def test_handle_mouse_selects_rightmost_sprite():
     view.action_buttons = []
     with patch.object(view, "update_play_button_state"), patch.object(
         view, "_highlight_turn"
-    ):
+    ), patch.object(view, "_animate_avatar_blink"):
         view.handle_mouse((5, 5))
     assert right.selected is True
     assert right in view.selected
@@ -112,7 +112,7 @@ def test_handle_mouse_calls_update_play_button_state():
     view.action_buttons = []
     with patch.object(view, "update_play_button_state") as upd, patch.object(
         view, "_highlight_turn"
-    ):
+    ), patch.object(view, "_animate_avatar_blink"):
         view.handle_mouse(sprite.rect.center)
         upd.assert_called()
 

--- a/tests/test_gui_overlays.py
+++ b/tests/test_gui_overlays.py
@@ -117,7 +117,7 @@ def test_undo_button_triggers_game_undo_last():
     view.game.snapshots.append("s2")
     with patch.object(
         view.game, "undo_last", return_value=True
-    ) as undo_mock, patch.object(view, "_highlight_turn"):
+    ) as undo_mock, patch.object(view, "_highlight_turn"), patch.object(view, "_animate_avatar_blink"):
         view.handle_mouse(undo_btn.rect.center)
         undo_mock.assert_called_once()
     pygame.quit()
@@ -419,7 +419,7 @@ def test_play_selected_triggers_flip():
         patch.object(view.game, "is_valid", return_value=(True, "")),
         patch.object(view.game, "process_play", return_value=False),
         patch.object(view.game, "next_turn"),
-        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_highlight_turn"), patch.object(view, "_animate_avatar_blink"),
         patch.object(view, "ai_turns"),
         patch.object(view, "update_hand_sprites"),
         patch.object(view, "_animate_flip") as flip,
@@ -439,7 +439,7 @@ def test_play_selected_triggers_glow():
         patch.object(view.game, "is_valid", return_value=(True, "")),
         patch.object(view.game, "process_play", return_value=False),
         patch.object(view.game, "next_turn"),
-        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_highlight_turn"), patch.object(view, "_animate_avatar_blink"),
         patch.object(view, "ai_turns"),
         patch.object(view, "update_hand_sprites"),
         patch.object(view, "_animate_flip", return_value="flip"),
@@ -462,7 +462,7 @@ def test_play_selected_triggers_bomb_reveal():
         patch.object(view.game, "is_valid", return_value=(True, "")),
         patch.object(view.game, "process_play", return_value=False),
         patch.object(view.game, "next_turn"),
-        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_highlight_turn"), patch.object(view, "_animate_avatar_blink"),
         patch.object(view, "ai_turns"),
         patch.object(view, "update_hand_sprites"),
         patch.object(view, "_animate_flip", return_value="flip"),
@@ -486,7 +486,7 @@ def test_ai_turns_triggers_pass_animation():
         patch.object(view.game, "is_valid", return_value=(True, "")),
         patch.object(view.game, "process_pass") as proc,
         patch.object(view.game, "next_turn"),
-        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_highlight_turn"), patch.object(view, "_animate_avatar_blink"),
         patch.object(view, "update_hand_sprites"),
         patch.object(view, "_animate_pass_text", return_value="pass") as anim,
         patch.object(view, "_start_animation") as start,
@@ -520,7 +520,7 @@ def test_pass_turn_shakes_on_invalid():
         patch.object(view, "_animate_shake", return_value="gen") as shake,
         patch.object(view, "_start_animation") as start,
         patch.object(sound, "play"),
-        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_highlight_turn"), patch.object(view, "_animate_avatar_blink"),
         patch.object(view, "ai_turns"),
     ):
         view.pass_turn()
@@ -536,7 +536,7 @@ def test_pass_turn_triggers_pass_animation():
         patch.object(view, "_animate_pass_text", return_value="pass") as anim,
         patch.object(view, "_start_animation") as start,
         patch.object(sound, "play"),
-        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_highlight_turn"), patch.object(view, "_animate_avatar_blink"),
         patch.object(view, "ai_turns"),
     ):
         view.pass_turn()
@@ -560,7 +560,7 @@ def test_undo_move_triggers_return_animation():
         patch.object(view, "_animate_return", return_value="gen") as ret,
         patch.object(view, "_start_animation") as start,
         patch.object(view, "update_hand_sprites"),
-        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_highlight_turn"), patch.object(view, "_animate_avatar_blink"),
     ):
         view.undo_move()
     undo_last.assert_called_once()
@@ -578,7 +578,7 @@ def test_ai_turns_triggers_glow_on_play():
         patch.object(view.game, "is_valid", return_value=(True, "")),
         patch.object(view.game, "process_play", return_value=False),
         patch.object(view.game, "next_turn"),
-        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_highlight_turn"), patch.object(view, "_animate_avatar_blink"),
         patch.object(view, "update_hand_sprites"),
         patch.object(view, "_animate_back", return_value="back"),
         patch.object(view, "_animate_glow", return_value="glow") as glow,
@@ -602,7 +602,7 @@ def test_ai_turns_triggers_bomb_reveal():
         patch.object(view.game, "is_valid", return_value=(True, "")),
         patch.object(view.game, "process_play", return_value=False),
         patch.object(view.game, "next_turn"),
-        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_highlight_turn"), patch.object(view, "_animate_avatar_blink"),
         patch.object(view, "update_hand_sprites"),
         patch.object(view, "_animate_back", return_value="back"),
         patch.object(view, "_animate_glow", return_value="glow"),

--- a/tests/test_memory_usage.py
+++ b/tests/test_memory_usage.py
@@ -33,10 +33,12 @@ def make_view():
         ):
             with patch.object(pygame_gui, 'load_card_images'):
                 with patch('pygame.time.Clock', return_value=clock):
-                    with patch.object(pygame_gui.GameView, '_highlight_turn'):
+                    with patch.object(pygame_gui.GameView, '_highlight_turn'), \
+                         patch.object(pygame_gui.GameView, '_animate_avatar_blink'):
                         view = pygame_gui.GameView(1, 1)
     # Ensure highlight_turn does not access the display during tests
     view._highlight_turn = lambda *a, **k: None
+    view._animate_avatar_blink = lambda *a, **k: None
     view._draw_frame = lambda *a, **k: None
     return view
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -46,6 +46,7 @@ def make_view():
                     view = pygame_gui.GameView(1, 1)
     # Avoid GUI operations during tests
     view._highlight_turn = lambda *a, **k: None
+    view._animate_avatar_blink = lambda *a, **k: None
     view._draw_frame = lambda *a, **k: None
     return view, clock
 


### PR DESCRIPTION
## Summary
- add avatar blink animation around player avatars
- trigger blink alongside turn highlight
- patch tests to disable avatar blink where needed

## Testing
- `pytest tests/test_gui_animations.py::test_highlight_turn_draws_at_player_position -q`
- `pytest tests/test_gui_input.py -q`
- `pytest tests/test_gui_overlays.py::test_play_selected_triggers_flip -q`


------
https://chatgpt.com/codex/tasks/task_e_686aa895c73c8326a16ab85dc9ec93a1