### PR TITLE
Implement simple AI thinking pause

### DIFF
--- a/pygame_gui/animations.py
+++ b/pygame_gui/animations.py
@@ -532,3 +532,12 @@ class AnimationMixin:
                 surf.set_alpha(alpha)
                 self.screen.blit(surf, sp.rect)
             dt = yield
+
+    def _animate_thinking(self, idx: int, duration: float = 0.3):
+        """Yield a short pause representing the AI 'thinking'."""
+        total = duration / self.animation_speed
+        elapsed = 0.0
+        dt = yield
+        while elapsed < total:
+            elapsed += dt
+            dt = yield

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -968,6 +968,9 @@ class GameView(AnimationMixin):
 
     def ai_turns(self):
         while not self.game.players[self.game.current_idx].is_human:
+            self._start_animation(
+                self._animate_thinking(self.game.current_idx)
+            )
             p = self.game.players[self.game.current_idx]
             cards = self.game.ai_play(self.game.current_combo)
             ok, _ = self.game.is_valid(p, cards, self.game.current_combo)


### PR DESCRIPTION
## Summary
- add `_animate_thinking` to provide a short pause for AI
- trigger the thinking pause at start of every AI loop

## Testing
- `coverage run -m pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686ab65595e88326893dd2f9a167552c