### PR TITLE
Animate AI plays sequentially

### DIFF
--- a/pygame_gui/animations.py
+++ b/pygame_gui/animations.py
@@ -541,3 +541,12 @@ class AnimationMixin:
         while elapsed < total:
             elapsed += dt
             dt = yield
+
+    def _animate_delay(self, duration: float = 0.2):
+        """Yield a generic pause with no visual effect."""
+        total = duration / self.animation_speed
+        elapsed = 0.0
+        dt = yield
+        while elapsed < total:
+            elapsed += dt
+            dt = yield

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -991,19 +991,21 @@ class GameView(AnimationMixin):
                 else:
                     sound.play("click")
                 dest = self._pile_center()
-                self._start_animation(
-                    self._animate_back(
-                        self._player_pos(self.game.current_idx),
-                        dest,
-                    )
-                )
+                start_pos = self._player_pos(self.game.current_idx)
                 glow_sprites = [
                     types.SimpleNamespace(rect=img.get_rect(center=dest))
                     for _, img in self.current_trick[-len(cards) :]
                 ]
-                self._start_animation(
-                    self._animate_glow(glow_sprites, PLAYER_COLORS[self.game.current_idx])
-                )
+
+                def seq():
+                    for _ in cards:
+                        yield from self._animate_back(start_pos, dest)
+                        yield from self._animate_delay(0.2)
+                    yield from self._animate_glow(
+                        glow_sprites, PLAYER_COLORS[self.game.current_idx]
+                    )
+
+                self._start_animation(seq())
             else:
                 sound.play("pass")
                 self.game.process_pass(p)

--- a/tests/test_gui_overlays.py
+++ b/tests/test_gui_overlays.py
@@ -589,7 +589,6 @@ def test_ai_turns_triggers_glow_on_play():
         view.ai_turns()
     glow.assert_called_once()
     assert glow.call_args.args[1] == pygame_gui.PLAYER_COLORS[1]
-    assert "glow" in [c.args[0] for c in start.call_args_list]
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- add new `_animate_delay` helper for pauses
- play each AI card back individually in `ai_turns`
- update glow-on-play test

## Testing
- `pytest tests/test_gui_overlays.py::test_ai_turns_triggers_glow_on_play -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686ab95eb8dc832692deb4ef244fc0ee