### PR TITLE
Add menu background

### DIFF
--- a/pygame_gui/overlays.py
+++ b/pygame_gui/overlays.py
@@ -608,7 +608,9 @@ class HowToPlayOverlay(Overlay):
             "First to shed all cards wins the round.",
         ]
         panel = self.view._hud_box(
-            lines, padding=10, bg_image=self.view.panel_image
+            lines,
+            padding=10,
+            bg_image=self.view.menu_background or self.view.panel_image,
         )
         rect = panel.get_rect(center=(w // 2, h // 2 - 20))
         surface.blit(panel, rect)
@@ -648,7 +650,9 @@ class TutorialOverlay(Overlay):
             "3. Beat opponents until you run out of cards.",
         ]
         panel = self.view._hud_box(
-            steps, padding=10, bg_image=self.view.panel_image
+            steps,
+            padding=10,
+            bg_image=self.view.menu_background or self.view.panel_image,
         )
         rect = panel.get_rect(center=(w // 2, h // 2 - 20))
         surface.blit(panel, rect)
@@ -702,7 +706,9 @@ class SavePromptOverlay(Overlay):
         w, h = surface.get_size()
         msg = f"Save your game before {self.label.lower()}?"
         panel = self.view._hud_box(
-            [msg], padding=10, bg_image=self.view.panel_image
+            [msg],
+            padding=10,
+            bg_image=self.view.menu_background or self.view.panel_image,
         )
         rect = panel.get_rect(center=(w // 2, h // 2 - 60))
         surface.blit(panel, rect)
@@ -794,7 +800,9 @@ class GameOverOverlay(Overlay):
             f"{i+1}. {n} ({c})" for i, (n, c) in enumerate(self.rankings)
         ]
         panel = self.view._hud_box(
-            lines, padding=10, bg_image=self.view.panel_image
+            lines,
+            padding=10,
+            bg_image=self.view.menu_background or self.view.panel_image,
         )
         rect = panel.get_rect(center=(w // 2, h // 2 - 20))
         surface.blit(panel, rect)

--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -103,6 +103,13 @@ class GameView(AnimationMixin):
                 self.main_menu_image = pygame.image.load(str(menu_path)).convert()
             except Exception:
                 self.main_menu_image = None
+
+        # Shared background for score panel and overlays
+        bg_path = ASSETS_DIR / "imgs" / "menu_background.png"
+        try:
+            self.menu_background = pygame.image.load(str(bg_path)).convert_alpha()
+        except Exception:
+            self.menu_background = None
         self._table_surface: Optional[pygame.Surface] = None
         self._update_table_surface()
         self._layout_zones()
@@ -1214,7 +1221,7 @@ class GameView(AnimationMixin):
                 if cards:
                     text = " ".join(str(c) for c in cards)
                     lines.append(f"{name}: {text}")
-        panel = self._hud_box(lines, padding=5, bg_image=self.panel_image)
+        panel = self._hud_box(lines, padding=5, bg_image=self.menu_background or self.panel_image)
         rect = panel.get_rect(topleft=self.score_pos)
         self.score_rect = rect
         if self.score_visible:


### PR DESCRIPTION
## Summary
- load new menu background texture and use for overlays and scoreboard
- apply updated background to save prompts, tutorial, etc.

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_686aea6f43d08326bf50d3be2e7106e4