### PR TITLE
Fix player labels

### DIFF
--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -1147,7 +1147,7 @@ class GameView(AnimationMixin):
         # Player labels and avatars
         for idx, p in enumerate(self.game.players):
             x, y = self._player_pos(idx)
-            txt = f"{p.name} ({len(p.hand)})"
+            txt = p.name
             color = (255, 255, 0) if idx == self.game.current_idx else (255, 255, 255)
             panel = self._hud_box(
                 [txt], text_color=color, padding=3, bg_image=self.panel_image
@@ -1159,7 +1159,7 @@ class GameView(AnimationMixin):
             combined.blit(avatar, (0, (combined.get_height() - ah) // 2))
             combined.blit(panel, (aw + LABEL_PAD, (combined.get_height() - ph) // 2))
             panel = combined
-            offset = card_h // 2 + spacing // 2 + LABEL_PAD
+            offset = card_h // 2 + spacing // 2 + LABEL_PAD * 2
             if idx == 0:
                 rect = panel.get_rect(midbottom=(x, y - offset))
             elif idx == 1:

--- a/tests/test_gui_animations.py
+++ b/tests/test_gui_animations.py
@@ -244,8 +244,8 @@ def test_draw_players_labels_use_padding():
     card_w = view.card_width
     card_h = int(card_w * 1.4)
     spacing = min(40, card_w)
-    pad_v = card_h // 2 + spacing // 2 + pygame_gui.LABEL_PAD
-    pad_h = card_h // 2 + spacing // 2 + pygame_gui.LABEL_PAD
+    pad_v = card_h // 2 + spacing // 2 + pygame_gui.LABEL_PAD * 2
+    pad_h = card_h // 2 + spacing // 2 + pygame_gui.LABEL_PAD * 2
 
     assert calls[0].args[1].midbottom == (100, 150 - pad_v)
     assert calls[1].args[1].midtop == (100, 50 + pad_v)


### PR DESCRIPTION
## Summary
- remove hand size from player labels
- offset player labels further from card sprites
- update tests for new padding

## Testing
- `pytest tests/test_gui_animations.py::test_draw_players_labels_use_padding tests/test_gui_overlays.py::test_draw_players_displays_trick_linearly -q`

------
https://chatgpt.com/codex/tasks/task_e_686af7cadb38832682d1bf51867c45e3