### PR TITLE
Update score overlay behaviour

### DIFF
--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -164,8 +164,6 @@ class GameView(AnimationMixin):
         self.score_visible = True
         self.score_pos: Tuple[int, int] = (10, 10)
         self.score_rect = pygame.Rect(self.score_pos, (0, 0))
-        self._dragging_score = False
-        self._drag_offset = (0, 0)
         self.action_buttons: List[Button] = []
         self._create_action_buttons()
         self.settings_button: Button
@@ -1208,18 +1206,11 @@ class GameView(AnimationMixin):
             self.screen.blit(img, rect)
 
     def draw_score_overlay(self) -> None:
-        """Render a scoreboard panel with last hands played."""
+        """Render a scoreboard panel showing total wins for each player."""
         lines = [
-            f"{p.name}: {len(p.hand)} ({self.win_counts.get(p.name, 0)})"
+            f"{p.name}: {self.win_counts.get(p.name, 0)}"
             for p in self.game.players
         ]
-        last = self.game.get_last_hands()
-        if any(cards for _, cards in last):
-            lines.append("Last:")
-            for name, cards in last:
-                if cards:
-                    text = " ".join(str(c) for c in cards)
-                    lines.append(f"{name}: {text}")
         panel = self._hud_box(lines, padding=5, bg_image=self.menu_background)
         rect = panel.get_rect(topleft=self.score_pos)
         self.score_rect = rect
@@ -1228,29 +1219,9 @@ class GameView(AnimationMixin):
         self.score_button.draw(self.screen)
 
     def _handle_score_event(self, event: pygame.event.Event) -> bool:
-        """Handle toggle and drag interactions for the score panel."""
-        if event.type == pygame.MOUSEBUTTONDOWN:
-            if self.score_button.rect.collidepoint(event.pos):
-                self.toggle_score()
-                return True
-            if self.score_visible and self.score_rect.collidepoint(event.pos):
-                self._dragging_score = True
-                self._drag_offset = (
-                    event.pos[0] - self.score_pos[0],
-                    event.pos[1] - self.score_pos[1],
-                )
-                return True
-        elif event.type == pygame.MOUSEBUTTONUP:
-            if self._dragging_score:
-                self._dragging_score = False
-                self._clamp_score_pos()
-                self._save_options()
-                return True
-        elif event.type == pygame.MOUSEMOTION and self._dragging_score:
-            self.score_pos = (
-                event.pos[0] - self._drag_offset[0],
-                event.pos[1] - self._drag_offset[1],
-            )
+        """Handle toggle interaction for the score panel."""
+        if event.type == pygame.MOUSEBUTTONDOWN and self.score_button.rect.collidepoint(event.pos):
+            self.toggle_score()
             return True
         return False
 

--- a/tests/test_gui_overlays.py
+++ b/tests/test_gui_overlays.py
@@ -1076,31 +1076,31 @@ def test_profile_overlay_new_profile_added():
     assert set(view.win_counts) - existing
 
 
-def test_handle_score_event_dragging():
+def test_handle_score_event_not_draggable():
     view, _ = make_view()
     view.score_visible = True
     # Position the score panel so it does not overlap the toggle button.
     view.score_pos = (50, 10)
     view.draw_score_overlay()
-    start_x, start_y = view.score_pos
+    start_pos = view.score_pos
     with patch.object(view, "_save_options") as save, patch.object(
         view, "_clamp_score_pos"
     ) as clamp:
         down = pygame.event.Event(
-            pygame.MOUSEBUTTONDOWN, {"pos": (start_x + 5, start_y + 5)}
+            pygame.MOUSEBUTTONDOWN, {"pos": (start_pos[0] + 5, start_pos[1] + 5)}
         )
-        assert view._handle_score_event(down) is True
+        assert view._handle_score_event(down) is False
         move = pygame.event.Event(
-            pygame.MOUSEMOTION, {"pos": (start_x + 10, start_y + 15)}
+            pygame.MOUSEMOTION, {"pos": (start_pos[0] + 10, start_pos[1] + 15)}
         )
-        assert view._handle_score_event(move) is True
-        assert view.score_pos == (start_x + 5, start_y + 10)
+        assert view._handle_score_event(move) is False
+        assert view.score_pos == start_pos
         up = pygame.event.Event(
-            pygame.MOUSEBUTTONUP, {"pos": (start_x + 10, start_y + 15)}
+            pygame.MOUSEBUTTONUP, {"pos": (start_pos[0] + 10, start_pos[1] + 15)}
         )
-        assert view._handle_score_event(up) is True
-        save.assert_called_once()
-        clamp.assert_called_once()
+        assert view._handle_score_event(up) is False
+        save.assert_not_called()
+        clamp.assert_not_called()
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- simplify score panel to only list win totals
- remove draggable score overlay
- update overlay event test

## Testing
- `pytest tests/test_gui_overlays.py::test_draw_score_overlay_positions_panel tests/test_gui_overlays.py::test_handle_score_event_not_draggable tests/test_gui_overlays.py::test_toggle_score_panel_changes_visibility -q`


------
https://chatgpt.com/codex/tasks/task_e_686afb0c9b48832697fdb684abf64eb6