### PR TITLE
Rotate side player card backs

### DIFF
--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -1135,16 +1135,18 @@ class GameView(AnimationMixin):
         start_rel, overlap_v = calc_start_and_overlap(
             screen_h - 2 * margin_v,
             len(left_player.hand),
-            card_h,
+            card_w,
             25,
-            card_h - 5,
+            card_w - 5,
         )
-        vert_spacing = card_h - overlap_v
+        vert_spacing = card_w - overlap_v
         y_start = start_rel + margin_v
         margin_h = horizontal_margin(card_w)
         for i in range(len(left_player.hand)):
             pos = (margin_h, y_start + i * vert_spacing)
-            sprite = CardBackSprite(pos, card_w, self.card_back_name)
+            sprite = CardBackSprite(
+                pos, card_w, self.card_back_name, rotation=90
+            )
             self.ai_sprites[1].add(sprite)
 
         # --- Right AI player (vertical) ---------------------------------
@@ -1152,16 +1154,18 @@ class GameView(AnimationMixin):
         start_rel, overlap_v = calc_start_and_overlap(
             screen_h - 2 * margin_v,
             len(right_player.hand),
-            card_h,
+            card_w,
             25,
-            card_h - 5,
+            card_w - 5,
         )
-        vert_spacing = card_h - overlap_v
+        vert_spacing = card_w - overlap_v
         y_start = start_rel + margin_v
-        x = screen_w - card_w - margin_h
+        x = screen_w - card_h - margin_h
         for i in range(len(right_player.hand)):
             pos = (x, y_start + i * vert_spacing)
-            sprite = CardBackSprite(pos, card_w, self.card_back_name)
+            sprite = CardBackSprite(
+                pos, card_w, self.card_back_name, rotation=-90
+            )
             self.ai_sprites[2].add(sprite)
 
         self.update_play_button_state()

--- a/tests/test_ai_rotation.py
+++ b/tests/test_ai_rotation.py
@@ -1,0 +1,79 @@
+import pygame
+import pygame_gui
+from unittest.mock import patch, MagicMock
+from conftest import DummyFont
+import pytest
+
+pytest.importorskip("pygame")
+
+
+def test_card_back_rotation_calls_pygame_rotate():
+    pygame.init()
+    pygame.font.init()
+    pygame.display.init()
+    surf = pygame.Surface((300, 200))
+    with patch("pygame.display.set_mode", return_value=surf):
+        with patch("pygame_gui.view.get_font", return_value=DummyFont()), patch(
+            "pygame_gui.helpers.get_font", return_value=DummyFont()
+        ), patch.object(pygame_gui, "load_card_images"), patch.object(
+            pygame_gui,
+            "get_card_image",
+            side_effect=lambda c, w: pygame.Surface((w, int(w * 1.4))),
+        ), patch.object(
+            pygame_gui,
+            "get_card_back",
+            side_effect=lambda name, w=1: pygame.Surface((w, int(w * 1.4))),
+        ):
+            view = pygame_gui.GameView(300, 200)
+
+    with patch(
+        "pygame.transform.rotate", side_effect=lambda s, a: s
+    ) as rotate, patch.object(
+        pygame_gui,
+        "get_card_back",
+        side_effect=lambda name, w=1: pygame.Surface((w, int(w * 1.4))),
+    ):
+        view.update_hand_sprites()
+    angles = [call.args[1] for call in rotate.call_args_list]
+    assert 90 in angles
+    assert -90 in angles
+    pygame.quit()
+
+
+def test_rotated_ai_sprites_stay_within_bounds_on_resize():
+    pygame.init()
+    pygame.font.init()
+    pygame.display.init()
+    surf_small = pygame.Surface((300, 200))
+    surf_large = pygame.Surface((600, 600))
+    set_mode = MagicMock(side_effect=[surf_small, surf_large])
+    with patch("pygame.display.set_mode", set_mode):
+        with patch("pygame_gui.view.get_font", return_value=DummyFont()), patch(
+            "pygame_gui.helpers.get_font", return_value=DummyFont()
+        ):
+            with patch.object(pygame_gui, "load_card_images"), patch.object(
+                pygame_gui,
+                "get_card_image",
+                side_effect=lambda c, w: pygame.Surface((w, int(w * 1.4))),
+            ), patch.object(
+                pygame_gui,
+                "get_card_back",
+                side_effect=lambda name, w=1: pygame.Surface((w, int(w * 1.4))),
+            ):
+                view = pygame_gui.GameView(300, 200)
+                view.on_resize(600, 600)
+
+                w, h = view.screen.get_size()
+                left_group = view.ai_sprites[1].sprites()
+                right_group = view.ai_sprites[2].sprites()
+
+                assert all(sp.rect.left >= 0 for sp in left_group)
+                assert all(sp.rect.right <= w for sp in left_group)
+                assert all(sp.rect.top >= 0 for sp in left_group)
+                assert all(sp.rect.bottom <= h for sp in left_group)
+
+                assert all(sp.rect.left >= 0 for sp in right_group)
+                assert all(sp.rect.right <= w for sp in right_group)
+                assert all(sp.rect.top >= 0 for sp in right_group)
+                assert all(sp.rect.bottom <= h for sp in right_group)
+    pygame.quit()


### PR DESCRIPTION
## Summary
- rotate left and right AI card backs 90 degrees
- keep rotated sprites within bounds on resize
- test for sprite rotation and bounds

## Testing
- `pytest tests/test_ai_rotation.py::test_card_back_rotation_calls_pygame_rotate -q`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_686b1b79a0948326bc2a800d2011a286