### PR TITLE
Switch to LayeredUpdates

### DIFF
--- a/pygame_gui/view.py
+++ b/pygame_gui/view.py
@@ -140,8 +140,8 @@ class GameView(AnimationMixin):
                 pass
         self.selected: List[CardSprite] = []
         self.current_trick: list[tuple[str, pygame.Surface]] = []
-        self.ai_sprites: List[pygame.sprite.RenderUpdates] = [
-            pygame.sprite.RenderUpdates() for _ in range(3)
+        self.ai_sprites: List[pygame.sprite.LayeredUpdates] = [
+            pygame.sprite.LayeredUpdates() for _ in range(3)
         ]
         self.running = True
         self.overlay: Optional[Overlay] = None
@@ -1104,8 +1104,8 @@ class GameView(AnimationMixin):
     def update_hand_sprites(self):
         """Create card sprites for all players with a simple table layout."""
 
-        self.hand_sprites = pygame.sprite.RenderUpdates()
-        self.ai_sprites = [pygame.sprite.RenderUpdates() for _ in range(3)]
+        self.hand_sprites = pygame.sprite.LayeredUpdates()
+        self.ai_sprites = [pygame.sprite.LayeredUpdates() for _ in range(3)]
 
         card_w = self.card_width
         card_h = int(card_w * 1.4)
@@ -1119,7 +1119,8 @@ class GameView(AnimationMixin):
             sprite = CardSprite(card, (start_x + i * spacing, y), card_w)
             sprite.pos.y = self.hand_y
             sprite.update()
-            self.hand_sprites.add(sprite)
+            sprite._layer = i
+            self.hand_sprites.add(sprite, layer=i)
 
         margin_v = bottom_margin(card_w)
 
@@ -1129,7 +1130,8 @@ class GameView(AnimationMixin):
         for i in range(len(top_player.hand)):
             pos = (start_x + i * spacing, 40)
             sprite = CardBackSprite(pos, card_w, self.card_back_name)
-            self.ai_sprites[0].add(sprite)
+            sprite._layer = i
+            self.ai_sprites[0].add(sprite, layer=i)
 
         # --- Left AI player (vertical) ----------------------------------
         left_player = self.game.players[1]
@@ -1148,7 +1150,8 @@ class GameView(AnimationMixin):
             sprite = CardBackSprite(
                 pos, card_w, self.card_back_name, rotation=90
             )
-            self.ai_sprites[1].add(sprite)
+            sprite._layer = i
+            self.ai_sprites[1].add(sprite, layer=i)
 
         # --- Right AI player (vertical) ---------------------------------
         right_player = self.game.players[3]
@@ -1167,7 +1170,8 @@ class GameView(AnimationMixin):
             sprite = CardBackSprite(
                 pos, card_w, self.card_back_name, rotation=-90
             )
-            self.ai_sprites[2].add(sprite)
+            sprite._layer = i
+            self.ai_sprites[2].add(sprite, layer=i)
 
         self.update_play_button_state()
 

--- a/tests/test_gui_animations.py
+++ b/tests/test_gui_animations.py
@@ -211,7 +211,7 @@ def test_draw_players_uses_draw_shadow():
             return_value=pygame.Surface((1, 1), pygame.SRCALPHA),
         ):
             sprite = pygame_gui.CardSprite(tien_len_full.Card("Spades", "3"), (0, 0), 1)
-    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
+    view.hand_sprites = pygame.sprite.LayeredUpdates(sprite)
     with patch.object(sprite, "draw_shadow") as ds:
         view.draw_players()
         ds.assert_called()
@@ -220,7 +220,7 @@ def test_draw_players_uses_draw_shadow():
 
 def test_draw_players_labels_use_padding():
     view, _ = make_view()
-    view.hand_sprites = pygame.sprite.RenderUpdates()
+    view.hand_sprites = pygame.sprite.LayeredUpdates()
     view.ai_sprites = []
     view.screen = MagicMock()
     view.screen.get_size.return_value = (200, 200)
@@ -255,8 +255,8 @@ def test_draw_players_labels_use_padding():
 
 def test_player_zone_rect_returns_union():
     view, _ = make_view()
-    view.hand_sprites = pygame.sprite.RenderUpdates()
-    view.ai_sprites = [pygame.sprite.RenderUpdates() for _ in range(3)]
+    view.hand_sprites = pygame.sprite.LayeredUpdates()
+    view.ai_sprites = [pygame.sprite.LayeredUpdates() for _ in range(3)]
     rects = [pygame.Rect(1, 2, 4, 5), pygame.Rect(4, 10, 2, 3)]
     sprites = [DummySprite() for _ in rects]
     for sp, r in zip(sprites, rects):
@@ -271,8 +271,8 @@ def test_draw_players_highlights_active_zone():
     view, _ = make_view()
     view.screen = MagicMock()
     view.screen.get_size.return_value = (100, 100)
-    view.hand_sprites = pygame.sprite.RenderUpdates()
-    view.ai_sprites = [pygame.sprite.RenderUpdates() for _ in range(3)]
+    view.hand_sprites = pygame.sprite.LayeredUpdates()
+    view.ai_sprites = [pygame.sprite.LayeredUpdates() for _ in range(3)]
     zone = pygame.Rect(0, 0, 10, 10)
     with patch.object(view, "_player_zone_rect", return_value=zone), patch.object(
         pygame_gui.view, "draw_glow"

--- a/tests/test_gui_input.py
+++ b/tests/test_gui_input.py
@@ -38,7 +38,7 @@ def test_handle_mouse_select_and_overlay():
     view, _ = make_view()
     sprite = DummySprite()
     center = sprite.rect.center
-    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
+    view.hand_sprites = pygame.sprite.LayeredUpdates(sprite)
     view.selected = []
     view.state = pygame_gui.GameState.PLAYING
     view.action_buttons = []
@@ -64,7 +64,7 @@ def test_handle_mouse_selects_rightmost_sprite():
     view, _ = make_view()
     left = DummySprite((5, 5))
     right = DummySprite((5, 5))
-    view.hand_sprites = pygame.sprite.RenderUpdates(left, right)
+    view.hand_sprites = pygame.sprite.LayeredUpdates(left, right)
     view.selected = []
     view.state = pygame_gui.GameState.PLAYING
     view.action_buttons = []
@@ -106,7 +106,7 @@ def test_update_play_button_state_disables_when_invalid():
 def test_handle_mouse_calls_update_play_button_state():
     view, _ = make_view()
     sprite = DummyCardSprite((5, 5))
-    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
+    view.hand_sprites = pygame.sprite.LayeredUpdates(sprite)
     view.selected = []
     view.state = pygame_gui.GameState.PLAYING
     view.action_buttons = []

--- a/tests/test_gui_overlays.py
+++ b/tests/test_gui_overlays.py
@@ -413,7 +413,7 @@ def test_play_selected_triggers_flip():
     view, _ = make_view()
     sprite = DummyCardSprite()
     view.selected = [sprite]
-    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
+    view.hand_sprites = pygame.sprite.LayeredUpdates(sprite)
     dest = view._pile_center()
     with (
         patch.object(view.game, "is_valid", return_value=(True, "")),
@@ -434,7 +434,7 @@ def test_play_selected_triggers_glow():
     view, _ = make_view()
     sprite = DummyCardSprite()
     view.selected = [sprite]
-    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
+    view.hand_sprites = pygame.sprite.LayeredUpdates(sprite)
     with (
         patch.object(view.game, "is_valid", return_value=(True, "")),
         patch.object(view.game, "process_play", return_value=False),
@@ -457,7 +457,7 @@ def test_play_selected_triggers_bomb_reveal():
     view, _ = make_view()
     sprite = DummyCardSprite()
     view.selected = [sprite]
-    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
+    view.hand_sprites = pygame.sprite.LayeredUpdates(sprite)
     with (
         patch.object(view.game, "is_valid", return_value=(True, "")),
         patch.object(view.game, "process_play", return_value=False),
@@ -502,7 +502,7 @@ def test_play_selected_shakes_on_invalid():
     view, _ = make_view()
     sprite = DummyCardSprite()
     view.selected = [sprite]
-    view.hand_sprites = pygame.sprite.RenderUpdates(sprite)
+    view.hand_sprites = pygame.sprite.LayeredUpdates(sprite)
     with (
         patch.object(view.game, "is_valid", return_value=(False, "bad")),
         patch.object(view, "_animate_shake", return_value="gen") as shake,
@@ -760,7 +760,7 @@ def test_reset_current_trick_starts_animation():
 
 def test_draw_players_displays_trick_linearly():
     view, _ = make_view()
-    view.hand_sprites = pygame.sprite.RenderUpdates()
+    view.hand_sprites = pygame.sprite.LayeredUpdates()
     view.ai_sprites = []
     surf1 = pygame.Surface((10, 20))
     surf2 = pygame.Surface((10, 20))


### PR DESCRIPTION
## Summary
- layer card sprites to keep active animations on top
- use LayeredUpdates groups in GameView
- adjust tests for new sprite group type

## Testing
- `pytest tests/test_gui_input.py::test_handle_key_shortcuts -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_686bd346cb908326b03efe3baeaa8aae