### PR TITLE
Add easing support to animations

### DIFF
--- a/pygame_gui/__init__.py
+++ b/pygame_gui/__init__.py
@@ -37,6 +37,7 @@ from .helpers import (
 )
 from .animations import AnimationMixin
 from .tween import Tween
+from . import easing
 from .anim_manager import AnimationManager
 from .overlays import (
     Button,
@@ -65,6 +66,7 @@ __all__ = [
     'load_card_images', 'get_font', 'get_card_image', 'get_card_back', 'CardSprite', 'CardBackSprite',
     'draw_surface_shadow', 'draw_glow', 'draw_tiled', 'clear_font_cache', '_mixer_ready', 'AnimationMixin', 'Tween',
     'AnimationManager',
+    'easing',
     'Button', 'Overlay', 'MainMenuOverlay',
     'InGameMenuOverlay', 'SettingsOverlay', 'GameSettingsOverlay', 'GraphicsOverlay',
     'AudioOverlay', 'RulesOverlay', 'HowToPlayOverlay', 'TutorialOverlay', 'SavePromptOverlay',

--- a/pygame_gui/anim_manager.py
+++ b/pygame_gui/anim_manager.py
@@ -20,7 +20,7 @@ class AnimationManager:
         return tween
 
     def tween_position(
-        self, dest: Tuple[float, float], duration: float, ease: Callable[[float], float] | None = None
+        self, dest: Tuple[float, float], duration: float, ease: str | Callable[[float], float] | None = None
     ) -> Tuple[Tween, Tween]:
         """Animate the sprite's centre position."""
         if hasattr(self.sprite, "pos"):
@@ -47,7 +47,7 @@ class AnimationManager:
         return tx, ty
 
     def tween_scale(
-        self, dest: float, duration: float, ease: Callable[[float], float] | None = None
+        self, dest: float, duration: float, ease: str | Callable[[float], float] | None = None
     ) -> Tween:
         start = getattr(self.sprite, "scale", 1.0)
 
@@ -60,7 +60,7 @@ class AnimationManager:
         return tw
 
     def tween_alpha(
-        self, dest: float, duration: float, ease: Callable[[float], float] | None = None
+        self, dest: float, duration: float, ease: str | Callable[[float], float] | None = None
     ) -> Tween:
         start = self.sprite.image.get_alpha() or 255
 

--- a/pygame_gui/easing.py
+++ b/pygame_gui/easing.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import math
+from typing import Callable, Dict
+
+
+def linear(t: float) -> float:
+    """Linear easing."""
+    return t
+
+
+def smooth(t: float) -> float:
+    """Smoothstep easing for gentle ease-in/out."""
+    return t * t * (3 - 2 * t)
+
+
+def ease_out_cubic(t: float) -> float:
+    """Cubic ease-out curve."""
+    return 1 - (1 - t) ** 3
+
+
+def elastic(t: float) -> float:
+    """Elastic ease-out curve."""
+    if t == 0 or t == 1:
+        return t
+    p = 0.3
+    s = p / 4
+    return math.pow(2, -10 * t) * math.sin((t - s) * (2 * math.pi) / p) + 1
+
+
+EASING_FUNCTIONS: Dict[str, Callable[[float], float]] = {
+    "linear": linear,
+    "smooth": smooth,
+    "ease-out-cubic": ease_out_cubic,
+    "elastic": elastic,
+}
+
+__all__ = [
+    "linear",
+    "smooth",
+    "ease_out_cubic",
+    "elastic",
+    "EASING_FUNCTIONS",
+]

--- a/pygame_gui/tween.py
+++ b/pygame_gui/tween.py
@@ -2,20 +2,23 @@ from __future__ import annotations
 
 from typing import Callable
 
-
-def linear(t: float) -> float:
-    """Default linear easing function."""
-    return t
+from .easing import EASING_FUNCTIONS, linear
 
 
 class Tween:
     """Simple tween for numeric values."""
 
-    def __init__(self, start: float, end: float, duration: float, ease: Callable[[float], float] | None = None):
+    def __init__(self, start: float, end: float, duration: float,
+                 ease: str | Callable[[float], float] | None = None):
         self.start = start
         self.end = end
         self.duration = max(duration, 1e-8)
-        self.ease = ease or linear
+        if isinstance(ease, str):
+            if ease not in EASING_FUNCTIONS:
+                raise KeyError(f"Unknown easing '{ease}'")
+            self.ease = EASING_FUNCTIONS[ease]
+        else:
+            self.ease = ease or linear
         self.elapsed = 0.0
 
     def update(self, dt: float) -> float:

--- a/tests/test_tween.py
+++ b/tests/test_tween.py
@@ -1,0 +1,20 @@
+import math
+import pytest
+
+from pygame_gui.tween import Tween
+from pygame_gui.easing import EASING_FUNCTIONS
+
+
+def test_tween_named_ease():
+    tw = Tween(0, 1, 1, ease="ease-out-cubic")
+    assert math.isclose(tw.update(0.5), EASING_FUNCTIONS["ease-out-cubic"](0.5))
+
+
+def test_tween_callable_ease():
+    tw = Tween(0, 1, 1, ease=lambda t: t * t)
+    assert math.isclose(tw.update(1.0), 1.0)
+
+
+def test_unknown_ease_raises():
+    with pytest.raises(KeyError):
+        Tween(0, 1, 1, ease="nope")


### PR DESCRIPTION
## Summary
- add easing curves module with common functions
- update `Tween` to accept an easing name or callback
- support easing strings in animation manager and animations
- expose `easing` via package init
- test `Tween` easing lookup

## Testing
- `pytest -q tests/test_tween.py`
- `pytest tests/test_gui_animations.py::test_animate_sprites_moves_to_destination -q`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686bdd6a7d748326a6312328b0898fb7