### PR TITLE
Refactor card dealing animations

### DIFF
--- a/pygame_gui/tween.py
+++ b/pygame_gui/tween.py
@@ -75,7 +75,7 @@ class Timeline:
 
     def update(self, dt: float) -> None:
         """Advance the timeline by ``dt`` seconds."""
-        while dt > 0:
+        while dt > 0 or (dt == 0 and self._current is None and self._steps):
             if self._current is None:
                 if not self._steps:
                     break
@@ -114,4 +114,3 @@ class Timeline:
             yield
 
         return gen()
-


### PR DESCRIPTION
## Summary
- refactor AnimationManager to support Timelines
- create a timeline per card in `_animate_deal` and `_animate_return`
- ensure the deal animation yields while AnimationManager runs
- adjust tests for new sequencing and add a check that other animations continue

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c140998848326ad7c17cb05186b9d