### PR TITLE
Optimize table redraw with dirty rects

### DIFF
--- a/tests/test_gui_animations.py
+++ b/tests/test_gui_animations.py
@@ -306,7 +306,7 @@ def test_animate_back_moves_to_destination():
     view.screen = MagicMock()
     img = pygame.Surface((1, 1))
     with patch.object(pygame_gui.animations, "get_card_back", return_value=img):
-        with patch("pygame.event.pump"), patch("pygame.display.flip"):
+        with patch("pygame.event.pump"), patch("pygame.display.update"):
             gen = view._animate_back((0, 0), (10, 5), duration=4 / 60)
             next(gen)
             steps = 0
@@ -329,7 +329,7 @@ def test_animate_flip_moves_to_destination():
     sprite = DummyCardSprite()
     with patch.object(
         pygame_gui, "get_card_back", return_value=pygame.Surface((1, 1))
-    ), patch("pygame.event.pump"), patch("pygame.display.flip"):
+    ), patch("pygame.event.pump"), patch("pygame.display.update"):
         gen = view._animate_flip([sprite], (10, 5), duration=4 / 60)
         next(gen)
         steps = 0
@@ -352,7 +352,7 @@ def test_animate_glow_draws_glow():
     sprite = DummyCardSprite()
     with patch.object(pygame_gui.animations, "draw_glow") as glow, patch(
         "pygame.event.pump"
-    ), patch("pygame.display.flip"):
+    ), patch("pygame.display.update"):
         gen = view._animate_glow([sprite], (1, 2, 3), duration=2 / 60)
         next(gen)
         gen.send(1 / 60)
@@ -367,7 +367,7 @@ def test_animate_glow_draws_glow():
 def test_bomb_reveal_draws_flash():
     view, _ = make_view()
     view.screen = MagicMock()
-    with patch("pygame.event.pump"), patch("pygame.display.flip"):
+    with patch("pygame.event.pump"), patch("pygame.display.update"):
         gen = view._bomb_reveal(duration=2 / 60)
         next(gen)
         gen.send(1 / 60)
@@ -386,7 +386,7 @@ def test_highlight_turn_draws_at_player_position():
     overlay_surface = MagicMock()
     with patch("pygame.Surface", return_value=overlay_surface) as surf_mock, patch(
         "pygame.event.pump"
-    ), patch("pygame.display.flip"), patch("pygame.draw.circle"), patch.object(
+    ), patch("pygame.display.update"), patch("pygame.draw.circle"), patch.object(
         view, "_player_pos", return_value=(50, 100)
     ) as pos:
         gen = view._highlight_turn(0, duration=2 / 60)
@@ -410,7 +410,7 @@ def test_animate_pass_text_draws_panel():
     panel = pygame.Surface((2, 2))
     with patch.object(view, "_player_zone_rect", return_value=zone) as rect_mock, patch.object(
         view, "_hud_box", return_value=panel
-    ) as hud, patch("pygame.event.pump"), patch("pygame.display.flip"):
+    ) as hud, patch("pygame.event.pump"), patch("pygame.display.update"):
         gen = view._animate_pass_text(1, duration=2 / 60)
         next(gen)
         gen.send(1 / 60)
@@ -426,7 +426,7 @@ def test_animate_pass_text_draws_panel():
 def test_state_methods_update_state():
     view, _ = make_view()
     assert view.state == pygame_gui.GameState.MENU
-    with patch("pygame.display.flip"):
+    with patch("pygame.display.update"):
         with patch.object(view, "ai_turns"):
             view.close_overlay()
         assert view.state == pygame_gui.GameState.PLAYING
@@ -446,7 +446,7 @@ def test_animate_sprites_speed():
     sprite = pygame.sprite.Sprite()
     sprite.image = pygame.Surface((1, 1))
     sprite.rect = sprite.image.get_rect()
-    with patch("pygame.event.pump"), patch("pygame.display.flip"):
+    with patch("pygame.event.pump"), patch("pygame.display.update"):
         view.animation_speed = 2.0
         gen = view._animate_sprites([sprite], (0, 0), duration=10 / 60)
         next(gen)
@@ -465,7 +465,7 @@ def test_animate_sprites_speed():
 def test_animate_back_speed():
     view, clock = make_view()
     with patch.object(pygame_gui, "get_card_back", return_value=pygame.Surface((1, 1))):
-        with patch("pygame.event.pump"), patch("pygame.display.flip"):
+        with patch("pygame.event.pump"), patch("pygame.display.update"):
             view.animation_speed = 0.5
             gen = view._animate_back((0, 0), (1, 1), duration=10 / 60)
             next(gen)
@@ -484,7 +484,7 @@ def test_animate_back_speed():
 
 def test_highlight_turn_speed():
     view, clock = make_view()
-    with patch("pygame.event.pump"), patch("pygame.display.flip"):
+    with patch("pygame.event.pump"), patch("pygame.display.update"):
         view.animation_speed = 2.0
         gen = view._highlight_turn(0, duration=10 / 60)
         next(gen)

--- a/tests/test_gui_overlays.py
+++ b/tests/test_gui_overlays.py
@@ -356,7 +356,7 @@ def test_vertical_spacing_changes_on_resize():
 
 def test_overlay_instances_created():
     view, _ = make_view()
-    with patch("pygame.display.flip"), patch("pygame.event.pump"):
+    with patch("pygame.display.update"), patch("pygame.event.pump"):
         view.show_menu()
         assert isinstance(view.overlay, pygame_gui.MainMenuOverlay)
         view.show_in_game_menu()
@@ -399,7 +399,7 @@ def test_draw_frame_with_overlay():
     view.screen.get_size.return_value = (100, 100)
     overlay_surface = MagicMock()
     with patch.object(view.screen, "blit") as blit, patch(
-        "pygame.display.flip"
+        "pygame.display.update"
     ) as flip, patch("pygame.Surface", return_value=overlay_surface), patch.object(
         view.score_button, "draw"
     ), patch("pygame_gui.view.draw_nine_patch"):
@@ -684,7 +684,7 @@ def test_toggle_score_panel_changes_visibility():
 def test_show_game_over_updates_win_counts():
     with patch("random.sample", return_value=tien_len_full.AI_NAMES[:3]):
         view, _ = make_view()
-    with patch.object(sound, "play"), patch("pygame.display.flip"):
+    with patch.object(sound, "play"), patch("pygame.display.update"):
         view.show_game_over("Player")
     assert view.win_counts["Player"] == 1
     pygame.quit()
@@ -886,7 +886,7 @@ def test_in_game_menu_buttons():
 def test_settings_button_opens_in_game_menu():
     view, _ = make_view()
     with patch.object(view, "_save_options"), patch.object(view, "ai_turns"), patch(
-        "pygame.display.flip"
+        "pygame.display.update"
     ):
         view.close_overlay()
     view.settings_button.callback = MagicMock()
@@ -897,7 +897,7 @@ def test_settings_button_opens_in_game_menu():
 
 def test_how_to_play_overlay_escape_returns_menu():
     view, _ = make_view()
-    with patch.object(view, "show_menu") as show_menu, patch("pygame.display.flip"):
+    with patch.object(view, "show_menu") as show_menu, patch("pygame.display.update"):
         view.show_how_to_play(from_menu=True)
         view.overlay.handle_event(
             pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_ESCAPE})
@@ -909,7 +909,7 @@ def test_how_to_play_overlay_escape_returns_menu():
 def test_tutorial_overlay_escape_returns_settings():
     view, _ = make_view()
     with patch.object(view, "show_settings") as show_settings, patch(
-        "pygame.display.flip"
+        "pygame.display.update"
     ):
         view.show_tutorial(from_menu=False)
         view.overlay.handle_event(
@@ -1028,7 +1028,7 @@ def test_overlay_buttons_reposition_after_resize(show_fn, args):
                 pygame_gui,
                 "get_card_image",
                 side_effect=lambda c, w: pygame.Surface((w, 1)),
-            ), patch("pygame.display.flip"):
+            ), patch("pygame.display.update"):
                 view = pygame_gui.GameView(300, 200)
                 getattr(view, show_fn)(*args)
                 before = [b.rect.topleft for b in view.overlay.buttons]
@@ -1074,7 +1074,7 @@ def test_options_persist_across_sessions(tmp_path):
 
 def test_rules_overlay_toggles_update_state():
     view, _ = make_view()
-    with patch("pygame.display.flip"):
+    with patch("pygame.display.update"):
         pygame_gui.GameView.show_rules(view)
     overlay = view.overlay
     attrs = [


### PR DESCRIPTION
## Summary
- reuse `_table_surface` when drawing players and return dirty rectangles
- update `_draw_frame` to update only dirty rects
- adjust tests for new `pygame.display.update` calls

## Testing
- `pytest tests/test_performance.py::test_average_frame_time_below_threshold -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2187d3b4832682b92d006ed0ec46