### PR TITLE
Add developer mode overlay

### DIFF
--- a/tienlen_gui/overlays.py
+++ b/tienlen_gui/overlays.py
@@ -363,17 +363,18 @@ class GameSettingsOverlay(Overlay):
         make_button(150, "ai_depth", [1, 2, 3], "AI Depth")
         make_button(200, "animation_speed", [0.5, 1.0, 2.0], "Anim Speed")
         make_button(250, "sort_mode", ["rank", "suit"], "Sort Mode")
+        make_button(300, "developer_mode", [False, True], "Dev Mode")
         self.buttons.append(
             Button(
                 "House Rules",
-                pygame.Rect(bx, by + 300, 240, 40),
+                pygame.Rect(bx, by + 350, 240, 40),
                 lambda: self.view.show_rules(from_menu=False),
                 font,
             )
         )
         btn = Button(
             "Back",
-            pygame.Rect(bx, by + 350, 240, 40),
+            pygame.Rect(bx, by + 400, 240, 40),
             self.view.show_settings,
             font,
             **load_button_images("button_back"),


### PR DESCRIPTION
## Summary
- add Developer Mode toggle in game settings overlay
- store AI move info for debugging and show AI hands in HUD when enabled
- map F3 to enable Developer Mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d41d6c63c832681a28512d72ff7db