### PR TITLE
Implement sliding overlay transitions

### DIFF
--- a/tienlen_gui/animations.py
+++ b/tienlen_gui/animations.py
@@ -409,7 +409,15 @@ class AnimationMixin:
         while True:
             progress = tween.update(dt)
             if slide:
-                pass
+                fs = from_surf.copy()
+                ts = to_surf.copy()
+                overlay = pygame.Surface((w, h), pygame.SRCALPHA)
+                fs_rect = fs.get_rect()
+                ts_rect = ts.get_rect()
+                fs_rect.x = int(-w * progress)
+                ts_rect.x = int(w * (1 - progress))
+                overlay.blit(fs, fs_rect)
+                overlay.blit(ts, ts_rect)
             else:
                 fs = from_surf.copy()
                 fs.set_alpha(int(255 * (1 - progress)))

--- a/tienlen_gui/overlay_manager.py
+++ b/tienlen_gui/overlay_manager.py
@@ -27,7 +27,11 @@ class OverlayMixin:
         """Switch to ``overlay`` using a brief transition."""
         old = self.overlay
         if old is not overlay:
-            self._start_animation(self._transition_overlay(old, overlay))
+            slide = (
+                old is not None
+                and {self.state, state} == {GameState.MENU, GameState.SETTINGS}
+            )
+            self._start_animation(self._transition_overlay(old, overlay, slide=slide))
         self.overlay = overlay
         self.state = state
 


### PR DESCRIPTION
## Summary
- add slide animation logic to overlay transitions
- slide overlays when switching between menu and settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea132680c8326b6d4eb975bc3aad6