### PR TITLE
Handle Esc key to open in‑game menu

### DIFF
--- a/tests/test_gui_input.py
+++ b/tests/test_gui_input.py
@@ -31,6 +31,10 @@ def test_handle_key_shortcuts():
     with patch.object(view, "show_settings") as show_settings:
         view.handle_key(pygame.K_o)
         show_settings.assert_called_once()
+
+    with patch.object(view, "show_in_game_menu") as show_in_game_menu:
+        view.handle_key(pygame.K_ESCAPE)
+        show_in_game_menu.assert_called_once()
     pygame.quit()
 
 

--- a/tienlen_gui/view.py
+++ b/tienlen_gui/view.py
@@ -825,7 +825,9 @@ class GameView(AnimationMixin, HUDMixin, OverlayMixin):
         event = pygame.event.Event(pygame.KEYDOWN, {"key": key})
         if self._dispatch_overlay_event(event):
             return
-        if key == pygame.K_RETURN:
+        if key == pygame.K_ESCAPE and self.state == GameState.PLAYING:
+            self.show_in_game_menu()
+        elif key == pygame.K_RETURN:
             self.play_selected()
         elif key == pygame.K_SPACE:
             self.pass_turn()


### PR DESCRIPTION
## Summary
- pressing Esc in playing state now pauses and shows the in-game menu
- test updated to ensure Esc opens the in-game menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eaa890c8c832691c57db3bad64df5