### PR TITLE
Add click sound on button press

### DIFF
--- a/tienlen_gui/overlays.py
+++ b/tienlen_gui/overlays.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pygame
 from typing import List, Callable, Optional, TYPE_CHECKING
 
+import sound
+
 from .helpers import (
     list_card_back_colors,
     list_table_textures,
@@ -80,6 +82,7 @@ class Button:
             and event.type == pygame.MOUSEBUTTONDOWN
             and self.rect.collidepoint(event.pos)
         ):
+            sound.play("click")
             self.callback()
 
 


### PR DESCRIPTION
## Summary
- add sound import to overlays
- play click sound when overlay buttons are pressed

## Testing
- `flake8`
- `pytest -q` *(fails: test_run_memory_usage)*

------
https://chatgpt.com/codex/tasks/task_e_686eb6cadcd4832689f52b853313518b