### PR TITLE
Fix clone rule options

### DIFF
--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -1,0 +1,12 @@
+from tien_len_full import Game, SUITS, RANKS
+
+
+def test_clone_preserves_rule_settings():
+    game = Game(allow_2_in_sequence=True, flip_suit_rank=True)
+    clone = game._clone()
+    assert clone.allow_2_in_sequence is True
+    assert clone.flip_suit_rank is True
+    block = len(RANKS)
+    suits = [clone.deck.cards[i * block].suit for i in range(len(SUITS))]
+    assert suits == list(reversed(SUITS))
+

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -819,7 +819,10 @@ class Game:
     def _clone(self) -> "Game":
         """Return a deep copy of the current game state."""
 
-        g = Game()
+        g = Game(
+            allow_2_in_sequence=self.allow_2_in_sequence,
+            flip_suit_rank=self.flip_suit_rank,
+        )
         g.from_dict(self.to_dict())
         g.ai_level = self.ai_level
         g.ai_difficulty = self.ai_difficulty


### PR DESCRIPTION
## Summary
- preserve `allow_2_in_sequence` and `flip_suit_rank` when cloning games
- ensure cloned games keep these options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f07baf7488326b2411daeefadac62