### PR TITLE
Pin dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ All of these preferences persist between sessions via the `options.json`
 file.
 
 Displaying card images requires the **Pillow** library, which is
-included in `requirements.txt`. Install dependencies (including Pillow
-for image support) with:
+included in `requirements.txt`. That file pins compatible versions of
+all dependencies. Install them (including Pillow for image support) with:
 
 ```bash
 pip install -r requirements.txt
@@ -161,7 +161,7 @@ disable sound explicitly. Place additional `.mp3` files in
 
 ## Running tests
 
-Install requirements first:
+Install the pinned requirements first:
 
 ```bash
 pip install -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,12 @@ version = "0.1.0"
 description = "Tiến Lên card game with CLI and Pygame GUI"
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = ["pillow", "pygame-ce"]
+dependencies = [
+    "pillow>=10,<12",
+    "pygame-ce>=2.5,<3",
+    "pytest>=8,<9",
+    "coverage>=7,<8",
+]
 
 [project.gui-scripts]
 tien-len = "tienlen_gui:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest
-coverage
-pillow
-pygame-ce
+pytest>=8,<9
+coverage>=7,<8
+pillow>=10,<12
+pygame-ce>=2.5,<3


### PR DESCRIPTION
## Summary
- pin compatible versions in requirements.txt
- mirror dependency versions in pyproject.toml
- mention pinned requirements in README
- update test instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1dcc773c83268af2a2d8b601d074