### PR TITLE
Fix CLI input loop and add regression test

### DIFF
--- a/tests/test_cli_input.py
+++ b/tests/test_cli_input.py
@@ -1,0 +1,25 @@
+from tien_len_full import Game, Card
+
+
+def test_cli_input_retries_on_invalid(monkeypatch):
+    game = Game()
+    player = game.players[0]
+    game.current_idx = 0
+    game.start_idx = 0
+    game.first_turn = False
+    player.hand = [Card('Spades', '3'), Card('Spades', '4')]
+
+    inputs = iter(['foo', 'bar'])
+    monkeypatch.setattr('builtins.input', lambda *args: next(inputs))
+
+    parse_results = iter([
+        ('play', [player.hand[0]]),
+        ('play', [player.hand[1]]),
+    ])
+    monkeypatch.setattr(Game, 'parse_input', lambda self, s, h: next(parse_results))
+
+    valid_results = iter([(False, 'bad'), (True, '')])
+    monkeypatch.setattr(Game, 'is_valid', lambda self, p, c, cur: next(valid_results))
+
+    move = game.cli_input(None)
+    assert move == [player.hand[1]]

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -535,6 +535,7 @@ class Game:
                             self.opening_card_str(),
                             self.opening_card_str(),
                         )
+                continue
 
     # AI helper functions
     def generate_valid_moves(self, player, current):


### PR DESCRIPTION
## Summary
- ensure `cli_input` continues on invalid plays
- test that invalid plays cause the prompt to retry

## Testing
- `pytest tests/test_cli_input.py -q`
- `pytest -q` *(fails: took too long? after 4+ minutes we aborted with KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686fbaad12588326affcc6459340563d