### PR TITLE
Fix tie-breaker logic for cards

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -148,3 +148,25 @@ def test_flip_suit_rank_sorting_and_deck_order():
     block = len(tl.RANKS)
     suits = [deck.cards[i * block].suit for i in range(len(tl.SUITS))]
     assert suits == list(reversed(tl.SUITS))
+
+
+def test_is_valid_suit_tie_breaker():
+    game = Game()
+    player = game.players[0]
+    game.first_turn = False
+
+    current = [Card('Hearts', '8')]
+    play = [Card('Diamonds', '8')]
+    ok, msg = game.is_valid(player, play, current)
+    assert ok
+
+
+def test_is_valid_sequence_tie_breaker():
+    game = Game()
+    player = game.players[0]
+    game.first_turn = False
+
+    current = make_cards(('Hearts', '3'), ('Spades', '4'), ('Hearts', '5'))
+    play = make_cards(('Spades', '3'), ('Hearts', '4'), ('Diamonds', '5'))
+    ok, msg = game.is_valid(player, play, current)
+    assert ok

--- a/tien_len_full.py
+++ b/tien_len_full.py
@@ -412,7 +412,13 @@ class Game:
 
         # Otherwise combos must match type and length and be higher in rank
         if combo == prev and len(cards) == len(current):
-            if max(RANKS.index(c.rank) for c in cards) > max(RANKS.index(c.rank) for c in current):
+            new_val = max(
+                (RANKS.index(c.rank), self.suit_index(c.suit)) for c in cards
+            )
+            cur_val = max(
+                (RANKS.index(c.rank), self.suit_index(c.suit)) for c in current
+            )
+            if new_val > cur_val:
                 return True, ''
 
         return False, 'Does not beat current'


### PR DESCRIPTION
## Summary
- allow suit to break rank ties in `is_valid`
- add regression tests for suit and sequence tie-breaking

## Testing
- `pytest -k 'is_valid_suit_tie_breaker or is_valid_sequence_tie_breaker' -q`

------
https://chatgpt.com/codex/tasks/task_e_68743723bb208326ad1fa83666f60e45