### PR TITLE
Display AI info in HUD

### DIFF
--- a/tests/test_gui_hud.py
+++ b/tests/test_gui_hud.py
@@ -25,6 +25,8 @@ def test_hud_panel_displays_count_and_last_move():
     lines = hud_box.call_args.args[0]
     assert lines[0] == f"{player.name} ({len(player.hand)})"
     assert lines[1].startswith(player.name)
+    assert any(line.startswith("Difficulty:") for line in lines)
+    assert any(line.startswith("Personality:") for line in lines)
     pygame.quit()
 
 

--- a/tienlen_gui/hud.py
+++ b/tienlen_gui/hud.py
@@ -47,6 +47,12 @@ class HUDPanel:
         if status:
             lines.append(status)
 
+        if not self.player.is_human:
+            lvl = self.view.game._ai_level_for(self.player)
+            per = self.view.game._ai_personality_for(self.player)
+            lines.append(f"Difficulty: {lvl}")
+            lines.append(f"Personality: {per}")
+
         info = self.view.ai_debug_info.get(self.idx)
         if self.view.developer_mode and info and not self.player.is_human:
             move, score = info


### PR DESCRIPTION
## Summary
- show AI difficulty and personality in HUD panels
- test HUD panel for AI info lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687598c5622c8326b32071b907159020