### PR TITLE
Document save/load menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ are handled automatically.
 - A compact score panel showing total wins can be toggled with the **S** button
   in the top-left corner.
 
+### Saving and loading
+
+Press the **Settings** button (or hit **Esc**) during a game to open the in-game
+menu. Here you can **Save Game** to write the current match to
+`~/.tien_len/saved_game.json` – the same directory that stores
+`options.json`. Selecting **Load Game** from this menu restores the last saved
+state so you can resume where you left off.
+
 ### AI personality and lookahead
 
 The **Options** menu exposes additional AI behaviour settings.  The


### PR DESCRIPTION
## Summary
- explain how to save and load a match from the in-game menu
- mention the save file path next to `options.json`

## Testing
- `pytest tests/test_cli_flags.py`
- `coverage xml`

------
https://chatgpt.com/codex/tasks/task_e_68759d4f646c8326be8d260c5b0c51d8