### PR TITLE
Update README with profile info

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ are handled automatically.
   enabled from the main menu.
 - On-screen **Play**, **Pass** and **Undo** buttons between your hand and the pile.
 - Optional player avatars loaded from `assets/avatars/`.
+- Player profiles with persistent win counts. Select a profile or create a new
+  one from the **Switch Profile** button on the main menu. Profile data is
+  stored alongside other settings in `~/.tien_len/options.json`.
 - Per-player HUD panels show remaining cards, the last move and whose turn it is.
 - Enable **Developer Mode** from the Options menu or press **F3** to reveal AI hands and move evaluations in these panels.
 - A small scoreboard at the top centre lists each player's remaining card count
@@ -82,7 +85,7 @@ are handled automatically.
 - A game log beside the scoreboard records the last four actions using a 12&nbsp;pt
   font and highlights the newest entry.
 - A compact score panel showing total wins can be toggled with the **S** button
-  in the top-left corner.
+  in the top-left corner. The panel tracks wins separately for each profile.
 
 ### AI personality and lookahead
 


### PR DESCRIPTION
## Summary
- document player profile support
- explain win count storage per profile
- mention accessing the profile selector from the main menu

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759d773384832699df0436068c7e9a