### PR TITLE
Update README shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ are handled automatically.
 - Press **F11** to toggle full-screen.
 - Sprites and layout adapt automatically when the window is resized.
 - Press **Enter** or **Space** for the usual shortcuts.
-- Settings and menu overlays are provided.
+- Settings and menu overlays are provided. Press **Esc** to open the menu,
+  **M** for the main menu and **O** for the options screen.
 - A dedicated *House Rules* screen lets you toggle optional rules.
   The *Flip Suit Rank* rule reverses suit ordering and can only be
   enabled from the main menu.


### PR DESCRIPTION
## Summary
- document Escape, **M**, and **O** shortcuts in GUI section

## Testing
- `coverage run -m pytest` *(fails: KeyboardInterrupt, 44 passed)*
- `coverage xml`

------
https://chatgpt.com/codex/tasks/task_e_68759d794fa08326a000c6429b093005