### PR TITLE
Add global AI toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ The **Options** menu exposes additional AI behaviour settings.  The
 **balanced** and **random** styles, altering how boldly opponents play.
 The *Lookahead* toggle makes the AI consider the next turn before
 committing to a move.
+An additional **Use Global AI** switch enables applying the same
+difficulty and personality to every opponent.  Enabling this clears any
+per-player overrides and removes the per-opponent setup panel from the
+menu.
 
 ### House Rules
 

--- a/tests/test_gui_overlays.py
+++ b/tests/test_gui_overlays.py
@@ -886,8 +886,12 @@ def test_in_game_menu_buttons():
     pygame.quit()
 
 
-def test_game_settings_overlay_includes_ai_setup():
+def test_game_settings_overlay_ai_setup_toggle():
     view, _ = make_view()
+    overlay = tienlen_gui.GameSettingsOverlay(view)
+    texts = [b.text for b in overlay.buttons]
+    assert "AI Setup" not in texts
+    view.use_global_ai_settings = False
     overlay = tienlen_gui.GameSettingsOverlay(view)
     texts = [b.text for b in overlay.buttons]
     assert "AI Setup" in texts

--- a/tienlen_gui/overlays.py
+++ b/tienlen_gui/overlays.py
@@ -353,8 +353,14 @@ class GameSettingsOverlay(Overlay):
                     idx = options.index(cur)
                     cur = options[(idx + 1) % len(options)]
                     setattr(self.view, attr, cur)
+                    if attr == "use_global_ai_settings" and cur:
+                        self.view.player_ai_levels.clear()
+                        self.view.player_ai_personality.clear()
                     self.view.apply_options()
-                    b.text = f"{label}: {cur if not isinstance(cur, bool) else ('On' if cur else 'Off')}"
+                    if attr == "use_global_ai_settings":
+                        self._layout()
+                    else:
+                        b.text = f"{label}: {cur if not isinstance(cur, bool) else ('On' if cur else 'Off')}"
 
                 return inner
 
@@ -387,24 +393,29 @@ class GameSettingsOverlay(Overlay):
         make_button(spacing * 4, "animation_speed", [0.5, 1.0, 2.0], "Anim Speed")
         make_button(spacing * 5, "sort_mode", ["rank", "suit"], "Sort Mode")
         make_button(spacing * 6, "developer_mode", [False, True], "Dev Mode")
-        ai_setup_btn = Button(
-            "AI Setup",
-            pygame.Rect(bx, by + spacing * 7, bw, bh),
-            self.view.show_ai_setup,
-            font,
-        )
-        self.buttons.append(ai_setup_btn)
+        make_button(spacing * 7, "use_global_ai_settings", [False, True], "Use Global AI")
+        if not self.view.use_global_ai_settings:
+            ai_setup_btn = Button(
+                "AI Setup",
+                pygame.Rect(bx, by + spacing * 8, bw, bh),
+                self.view.show_ai_setup,
+                font,
+            )
+            self.buttons.append(ai_setup_btn)
+            offset_extra = 1
+        else:
+            offset_extra = 0
         self.buttons.append(
             Button(
                 "House Rules",
-                pygame.Rect(bx, by + spacing * 8, bw, bh),
+                pygame.Rect(bx, by + spacing * (8 + offset_extra), bw, bh),
                 lambda: self.view.show_rules(from_menu=False),
                 font,
             )
         )
         btn = Button(
             "Back",
-            pygame.Rect(bx, by + spacing * 9, bw, bh),
+            pygame.Rect(bx, by + spacing * (9 + offset_extra), bw, bh),
             self.view.show_settings,
             font,
             **load_button_images("button_back"),

--- a/tienlen_gui/view.py
+++ b/tienlen_gui/view.py
@@ -159,6 +159,7 @@ class GameView(AnimationMixin, HUDMixin, OverlayMixin):
         self.rule_no_2s = True
         self.score_visible = True
         self.developer_mode = False
+        self.use_global_ai_settings = True
         self.ai_debug_info: Dict[int, tuple[str, Optional[float]]] = {}
         self.score_pos: Tuple[int, int] = (10, 10)
         self.score_rect = pygame.Rect(self.score_pos, (0, 0))
@@ -201,6 +202,9 @@ class GameView(AnimationMixin, HUDMixin, OverlayMixin):
         )
         self.rule_no_2s = opts.get("rule_no_2s", self.rule_no_2s)
         self.developer_mode = opts.get("developer_mode", self.developer_mode)
+        self.use_global_ai_settings = opts.get(
+            "use_global_ai_settings", self.use_global_ai_settings
+        )
         self.score_visible = opts.get("score_visible", self.score_visible)
         self.score_pos = tuple(opts.get("score_pos", list(self.score_pos)))
         win_data = opts.get("win_counts", {})
@@ -635,6 +639,7 @@ class GameView(AnimationMixin, HUDMixin, OverlayMixin):
             "rule_flip_suit_rank": self.rule_flip_suit_rank,
             "rule_no_2s": self.rule_no_2s,
             "developer_mode": self.developer_mode,
+            "use_global_ai_settings": self.use_global_ai_settings,
             "fullscreen": self.fullscreen,
             "fps_limit": self.fps_limit,
             "score_visible": self.score_visible,
@@ -674,13 +679,20 @@ class GameView(AnimationMixin, HUDMixin, OverlayMixin):
         self.game.set_personality(self.ai_personality)
         self.game.ai_lookahead = self.ai_lookahead
         self.game.ai_depth = self.ai_depth
-        for pl in self.game.players:
-            lvl = self.player_ai_levels.get(pl.name)
-            if lvl is not None:
-                self.game.set_player_ai_level(pl.name, lvl)
-            per = self.player_ai_personality.get(pl.name)
-            if per is not None:
-                self.game.set_player_personality(pl.name, per)
+        if self.use_global_ai_settings:
+            self.player_ai_levels.clear()
+            self.player_ai_personality.clear()
+            for pl in self.game.players:
+                self.game.set_player_ai_level(pl.name, None)
+                self.game.set_player_personality(pl.name, None)
+        else:
+            for pl in self.game.players:
+                lvl = self.player_ai_levels.get(pl.name)
+                if lvl is not None:
+                    self.game.set_player_ai_level(pl.name, lvl)
+                per = self.player_ai_personality.get(pl.name)
+                if per is not None:
+                    self.game.set_player_personality(pl.name, per)
         self.game.allow_2_in_sequence = not self.rule_no_2s
         self.game.flip_suit_rank = self.rule_flip_suit_rank
         sound.set_volume(self.fx_volume)


### PR DESCRIPTION
## Summary
- add `use_global_ai_settings` field to GameView with persistence
- include global AI toggle in settings overlay
- clear per-player overrides when global AI is enabled
- hide per-opponent panel when using global AI
- document this new behaviour
- adjust tests for new toggle

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687645cfdce08326955a318cdccf5a8f