### PR TITLE
Add tests for per-player AI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,12 @@ The **Options** menu exposes additional AI behaviour settings.  The
 *AI Personality* selector cycles through **aggressive**, **defensive**,
 **balanced** and **random** styles, altering how boldly opponents play.
 The *Lookahead* toggle makes the AI consider the next turn before
-committing to a move.
-An additional **Use Global AI** switch enables applying the same
-difficulty and personality to every opponent.  Enabling this clears any
-per-player overrides and removes the per-opponent setup panel from the
-menu.
+committing to a move. A **Use Global AI** toggle at the bottom of this
+screen decides whether the chosen difficulty and personality apply to
+every opponent. Disabling it reveals an **AI Setup** button that opens a
+panel listing each CPU player so you can configure their difficulty and
+personality individually. Re-enabling the global option clears any
+per-player overrides and hides the setup panel.
 
 ### House Rules
 

--- a/tests/test_ai_settings.py
+++ b/tests/test_ai_settings.py
@@ -1,0 +1,36 @@
+import pytest
+from unittest.mock import patch
+import tien_len_full
+
+
+@pytest.mark.parametrize("ident_attr", [1, "name", "obj"])
+def test_set_player_ai_level_accepts_multiple_id_forms(ident_attr):
+    with patch('random.sample', return_value=tien_len_full.AI_NAMES[:3]):
+        game = tien_len_full.Game()
+    player = game.players[1]
+    if ident_attr == 1:
+        ident = 1
+    elif ident_attr == "name":
+        ident = player.name
+    else:
+        ident = player
+    game.set_player_ai_level(ident, "Hard")
+    assert player.ai_level == "Hard"
+
+
+@pytest.mark.parametrize("ident_attr", [1, "name", "obj"])
+def test_set_player_personality_accepts_multiple_id_forms(ident_attr):
+    with patch('random.sample', return_value=tien_len_full.AI_NAMES[:3]):
+        game = tien_len_full.Game()
+    player = game.players[1]
+    if ident_attr == 1:
+        ident = 1
+    elif ident_attr == "name":
+        ident = player.name
+    else:
+        ident = player
+    game.set_player_personality(ident, "aggressive")
+    assert player.ai_personality == "aggressive"
+    game.set_player_personality(ident, None)
+    assert player.ai_personality is None
+

--- a/tests/test_gui_hud.py
+++ b/tests/test_gui_hud.py
@@ -69,3 +69,16 @@ def test_hud_highlight_switches_on_turn_change():
         hud2.draw(surf)
         assert glow.call_count == 1
     pygame.quit()
+
+def test_hud_panel_shows_custom_ai_settings():
+    view, _ = make_view()
+    player = view.game.players[1]
+    view.game.set_player_ai_level(player, "Hard")
+    view.game.set_player_personality(player, "defensive")
+    hud = tienlen_gui.HUDPanel(view, 1)
+    with patch.object(view, "_hud_box", return_value=pygame.Surface((1, 1))) as hud_box:
+        hud._create_surface()
+    lines = hud_box.call_args.args[0]
+    assert f"Difficulty: Hard" in lines
+    assert f"Personality: defensive" in lines
+    pygame.quit()

--- a/tests/test_gui_overlays.py
+++ b/tests/test_gui_overlays.py
@@ -1087,6 +1087,25 @@ def test_options_persist_across_sessions(tmp_path):
     assert new_view.win_counts["Player"] == 3
     assert new_view.fps_limit == 30
 
+def test_per_player_ai_settings_persist(tmp_path):
+    opt = tmp_path / "opts.json"
+    with patch.object(tienlen_gui, "OPTIONS_FILE", opt):
+        with patch("random.sample", return_value=tien_len_full.AI_NAMES[:3]):
+            view, _ = make_view()
+        view.use_global_ai_settings = False
+        p1 = view.game.players[1].name
+        p2 = view.game.players[2].name
+        view.game.set_player_ai_level(p1, "Hard")
+        view.game.set_player_personality(p2, "aggressive")
+        view._save_options()
+        with patch("random.sample", return_value=tien_len_full.AI_NAMES[:3]):
+            new_view, _ = make_view()
+    assert new_view.use_global_ai_settings is False
+    assert new_view.player_ai_levels[p1] == "Hard"
+    assert new_view.player_ai_personality[p2] == "aggressive"
+    assert new_view.game.players[1].name == p1
+    assert new_view.game.players[1].ai_level == "Hard"
+    assert new_view.game.players[2].ai_personality == "aggressive"
 
 def test_rules_overlay_toggles_update_state():
     view, _ = make_view()


### PR DESCRIPTION
## Summary
- add tests for Game.set_player_ai_level and set_player_personality
- test HUD panel with custom AI settings
- ensure per-player AI settings persist when saving/loading options
- document global vs per-opponent configuration in README

## Testing
- `coverage run -m pytest`
- `coverage xml`


------
https://chatgpt.com/codex/tasks/task_e_68766de046dc832693052c0038772326