### PR TITLE
Add hint button and more rule toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ are handled automatically.
 - A dedicated *House Rules* screen lets you toggle optional rules.
   The *Flip Suit Rank* rule reverses suit ordering and can only be
   enabled from the main menu.
-- On-screen **Play**, **Pass** and **Undo** buttons between your hand and the pile.
+- On-screen **Play**, **Pass**, **Hint** and **Undo** buttons between your hand and the pile.
+- Click **Hint** to automatically highlight a suggested play.
 - Optional player avatars loaded from `assets/avatars/`.
 - Player profiles with persistent win counts. Select a profile or create a new
   one from the **Switch Profile** button on the main menu. Profile data is
@@ -114,9 +115,9 @@ per-player overrides and hides the setup panel.
 The *House Rules* screen contains optional rule switches:
 
 - **Allow 2 in straights** – permits sequences containing the rank 2.
-- **“Chặt” bomb** – four-of-a-kind bombs can always beat a single 2.
-- **Chain cutting** – lets a higher sequence interrupt an existing one.
-- **Tứ Quý hierarchy** – bombs outrank each other by rank.
+- **Chặt bomb** – bombs can trump any non-bomb hand.
+- **Chain cutting** – longer sequences may interrupt a smaller one.
+- **Tứ Quý hierarchy** – higher ranked bombs beat lower ones.
 - **Flip Suit Rank** – reverses suit order so Hearts outranks Spades.
 
 All of these preferences persist between sessions via the `options.json`

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -2,10 +2,19 @@ from tien_len_full import Game, SUITS, RANKS
 
 
 def test_clone_preserves_rule_settings():
-    game = Game(allow_2_in_sequence=True, flip_suit_rank=True)
+    game = Game(
+        allow_2_in_sequence=True,
+        flip_suit_rank=True,
+        bomb_override=True,
+        chain_cutting=True,
+        bomb_hierarchy=True,
+    )
     clone = game._clone()
     assert clone.allow_2_in_sequence is True
     assert clone.flip_suit_rank is True
+    assert clone.bomb_override is True
+    assert clone.chain_cutting is True
+    assert clone.bomb_hierarchy is True
     block = len(RANKS)
     suits = [clone.deck.cards[i * block].suit for i in range(len(SUITS))]
     assert suits == list(reversed(SUITS))

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -71,7 +71,7 @@ def test_player_sort_and_bombs():
 
 
 def test_is_valid_basic_rules():
-    game = Game(flip_suit_rank=False)
+    game = Game(flip_suit_rank=False, bomb_override=True, bomb_hierarchy=True)
     starter = game.players[0]
     game.current_idx = 0
     game.start_idx = 0

--- a/tienlen_gui/overlays.py
+++ b/tienlen_gui/overlays.py
@@ -236,7 +236,7 @@ class InGameMenuOverlay(Overlay):
         bw, bh = self._button_size()
         spacing = self._spacing()
         bx = w // 2 - bw // 2
-        by = h // 2 - int(spacing * 3)
+        by = h // 2 - int(spacing * 4)
         self.buttons = [
             Button(
                 "Resume Game",
@@ -712,10 +712,13 @@ class RulesOverlay(Overlay):
 
         make_button(0, "rule_flip_suit_rank", "Flip Suit Rank")
         make_button(spacing, "rule_no_2s", "No 2s in straights")
+        make_button(spacing * 2, "rule_bomb_override", "Chặt bomb")
+        make_button(spacing * 3, "rule_chain_cutting", "Chain cutting")
+        make_button(spacing * 4, "rule_bomb_hierarchy", "Tứ Quý hierarchy")
         self.buttons.append(
             Button(
                 "Back",
-                pygame.Rect(bx, by + spacing * 2, bw, bh),
+                pygame.Rect(bx, by + spacing * 5, bw, bh),
                 self.back_callback,
                 font,
                 **load_button_images("button_back"),


### PR DESCRIPTION
## Summary
- add new optional rules with persistence
- update Rules overlay for additional toggles
- include a Hint button in the action bar
- connect hint selection logic in GUI
- update tests and documentation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769c10ca308326a1e1f6ca140726f7