### PR TITLE
Add headless Pygame fixtures and snapshot tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203,W503

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,7 @@ line_length = 120
 branch = true
 omit = ["tienlen_gui/*.py"]
 
+[tool.mypy]
+ignore_missing_imports = true
+
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    gui: tests that require pygame display

--- a/tests/test_ai_rotation.py
+++ b/tests/test_ai_rotation.py
@@ -1,10 +1,14 @@
+from unittest.mock import MagicMock, patch
+
 import pygame
-import tienlen_gui
-from unittest.mock import patch, MagicMock
-from conftest import DummyFont
 import pytest
 
+import tienlen_gui
+from conftest import DummyFont
+
 pytest.importorskip("pygame")
+
+pytestmark = pytest.mark.gui
 
 
 def test_card_back_rotation_calls_pygame_rotate():
@@ -13,25 +17,30 @@ def test_card_back_rotation_calls_pygame_rotate():
     pygame.display.init()
     surf = pygame.Surface((300, 200))
     with patch("pygame.display.set_mode", return_value=surf):
-        with patch("tienlen_gui.view.get_font", return_value=DummyFont()), patch(
-            "tienlen_gui.helpers.get_font", return_value=DummyFont()
-        ), patch.object(tienlen_gui, "load_card_images"), patch.object(
-            tienlen_gui,
-            "get_card_image",
-            side_effect=lambda c, w: pygame.Surface((w, int(w * 1.4))),
-        ), patch.object(
-            tienlen_gui,
-            "get_card_back",
-            side_effect=lambda name, w=1: pygame.Surface((w, int(w * 1.4))),
+        with (
+            patch("tienlen_gui.view.get_font", return_value=DummyFont()),
+            patch("tienlen_gui.helpers.get_font", return_value=DummyFont()),
+            patch.object(tienlen_gui, "load_card_images"),
+            patch.object(
+                tienlen_gui,
+                "get_card_image",
+                side_effect=lambda c, w: pygame.Surface((w, int(w * 1.4))),
+            ),
+            patch.object(
+                tienlen_gui,
+                "get_card_back",
+                side_effect=lambda name, w=1: pygame.Surface((w, int(w * 1.4))),
+            ),
         ):
             view = tienlen_gui.GameView(300, 200)
 
-    with patch(
-        "pygame.transform.rotate", side_effect=lambda s, a: s
-    ) as rotate, patch.object(
-        tienlen_gui,
-        "get_card_back",
-        side_effect=lambda name, w=1: pygame.Surface((w, int(w * 1.4))),
+    with (
+        patch("pygame.transform.rotate", side_effect=lambda s, a: s) as rotate,
+        patch.object(
+            tienlen_gui,
+            "get_card_back",
+            side_effect=lambda name, w=1: pygame.Surface((w, int(w * 1.4))),
+        ),
     ):
         view.update_hand_sprites()
     angles = [call.args[1] for call in rotate.call_args_list]
@@ -48,17 +57,22 @@ def test_rotated_ai_sprites_stay_within_bounds_on_resize():
     surf_large = pygame.Surface((600, 600))
     set_mode = MagicMock(side_effect=[surf_small, surf_large])
     with patch("pygame.display.set_mode", set_mode):
-        with patch("tienlen_gui.view.get_font", return_value=DummyFont()), patch(
-            "tienlen_gui.helpers.get_font", return_value=DummyFont()
+        with (
+            patch("tienlen_gui.view.get_font", return_value=DummyFont()),
+            patch("tienlen_gui.helpers.get_font", return_value=DummyFont()),
         ):
-            with patch.object(tienlen_gui, "load_card_images"), patch.object(
-                tienlen_gui,
-                "get_card_image",
-                side_effect=lambda c, w: pygame.Surface((w, int(w * 1.4))),
-            ), patch.object(
-                tienlen_gui,
-                "get_card_back",
-                side_effect=lambda name, w=1: pygame.Surface((w, int(w * 1.4))),
+            with (
+                patch.object(tienlen_gui, "load_card_images"),
+                patch.object(
+                    tienlen_gui,
+                    "get_card_image",
+                    side_effect=lambda c, w: pygame.Surface((w, int(w * 1.4))),
+                ),
+                patch.object(
+                    tienlen_gui,
+                    "get_card_back",
+                    side_effect=lambda name, w=1: pygame.Surface((w, int(w * 1.4))),
+                ),
             ):
                 view = tienlen_gui.GameView(300, 200)
                 view.on_resize(600, 600)

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -1,13 +1,13 @@
-import os
 from unittest.mock import patch
-import pytest
+
 import pygame
+import pytest
+
 import tienlen_gui
 
 pytest.importorskip("pygame")
 
-# Use dummy video driver so no window is opened
-os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+pytestmark = pytest.mark.gui
 
 
 class DummyFont:
@@ -30,14 +30,17 @@ def make_view():
     pygame.display.init()
     tienlen_gui.clear_font_cache()
     clock = DummyClock()
-    with patch('pygame.display.set_mode', return_value=pygame.Surface((1, 1))):
-        with patch('tienlen_gui.view.get_font', return_value=DummyFont()), patch(
-            'tienlen_gui.helpers.get_font', return_value=DummyFont()
+    with patch("pygame.display.set_mode", return_value=pygame.Surface((1, 1))):
+        with (
+            patch("tienlen_gui.view.get_font", return_value=DummyFont()),
+            patch("tienlen_gui.helpers.get_font", return_value=DummyFont()),
         ):
-            with patch.object(tienlen_gui, 'load_card_images'):
-                with patch('pygame.time.Clock', return_value=clock):
-                    with patch.object(tienlen_gui.GameView, '_highlight_turn'), \
-                         patch.object(tienlen_gui.GameView, '_animate_avatar_blink'):
+            with patch.object(tienlen_gui, "load_card_images"):
+                with patch("pygame.time.Clock", return_value=clock):
+                    with (
+                        patch.object(tienlen_gui.GameView, "_highlight_turn"),
+                        patch.object(tienlen_gui.GameView, "_animate_avatar_blink"),
+                    ):
                         view = tienlen_gui.GameView(1, 1)
     # Ensure highlight_turn does not access the display during tests
     view._highlight_turn = lambda *a, **k: None
@@ -50,15 +53,14 @@ def test_event_loop_handles_quit():
     view = make_view()
 
     seq = [
-        [pygame.event.Event(pygame.MOUSEBUTTONDOWN, {'pos': (0, 0)})],
+        [pygame.event.Event(pygame.MOUSEBUTTONDOWN, {"pos": (0, 0)})],
         [pygame.event.Event(pygame.QUIT, {})],
     ]
 
     def side_effect():
         return seq.pop(0) if seq else []
 
-    with patch('pygame.event.get', side_effect=side_effect) as get_mock, \
-         patch('pygame.quit') as quit_mock:
+    with patch("pygame.event.get", side_effect=side_effect) as get_mock, patch("pygame.quit") as quit_mock:
         view.run()
         assert get_mock.call_count >= 2
         quit_mock.assert_called_once()

--- a/tests/test_get_font.py
+++ b/tests/test_get_font.py
@@ -1,9 +1,13 @@
-import pytest
-import pygame
-import tienlen_gui
 from pathlib import Path
 
+import pygame
+import pytest
+
+import tienlen_gui
+
 pytest.importorskip("pygame")
+
+pytestmark = pytest.mark.gui
 
 
 def test_get_font_initializes_pygame_font(monkeypatch):

--- a/tests/test_gui_animations.py
+++ b/tests/test_gui_animations.py
@@ -1,25 +1,27 @@
-import os
 import math
-from unittest.mock import patch, MagicMock
 from pathlib import Path
-import pytest
+from unittest.mock import MagicMock, patch
+
 import pygame
-import tienlen_gui
+import pytest
+
 import tienlen
-from conftest import make_view, DummyFont, DummySprite, DummyCardSprite
+import tienlen_gui
+from conftest import DummyCardSprite, DummyFont, DummySprite, make_view
 
 pytest.importorskip("PIL")
 pytest.importorskip("pygame")
 
-os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+pytestmark = pytest.mark.gui
 
 
 def test_card_sprite_draw_shadow_blits():
     pygame.init()
     pygame.font.init()
     pygame.display.init()
-    with patch("tienlen_gui.helpers.get_font", return_value=DummyFont()), patch(
-        "tienlen_gui.view.get_font", return_value=DummyFont()
+    with (
+        patch("tienlen_gui.helpers.get_font", return_value=DummyFont()),
+        patch("tienlen_gui.view.get_font", return_value=DummyFont()),
     ):
         with patch.object(
             tienlen_gui,
@@ -50,9 +52,7 @@ def test_button_draw_uses_nine_patch():
             "pressed_image": pygame.Surface((5, 5)),
         },
     )
-    with patch.object(tienlen_gui.overlays, "draw_nine_patch") as nine, patch(
-        "pygame.draw.rect"
-    ) as rect_draw:
+    with patch.object(tienlen_gui.overlays, "draw_nine_patch") as nine, patch("pygame.draw.rect") as rect_draw:
         btn.draw(surf)
     nine.assert_called_once()
     rect_draw.assert_not_called()
@@ -63,8 +63,9 @@ def test_card_sprite_draw_shadow_uses_default_constants():
     pygame.init()
     pygame.font.init()
     pygame.display.init()
-    with patch("tienlen_gui.helpers.get_font", return_value=DummyFont()), patch(
-        "tienlen_gui.view.get_font", return_value=DummyFont()
+    with (
+        patch("tienlen_gui.helpers.get_font", return_value=DummyFont()),
+        patch("tienlen_gui.view.get_font", return_value=DummyFont()),
     ):
         with patch.object(
             tienlen_gui,
@@ -73,6 +74,7 @@ def test_card_sprite_draw_shadow_uses_default_constants():
         ):
             sprite = tienlen_gui.CardSprite(tienlen.Card("Spades", "3"), (0, 0), 1)
     from tienlen_gui import helpers as h
+
     h._SHADOW_CACHE.clear()
     base = MagicMock()
     shadow = MagicMock()
@@ -100,8 +102,9 @@ def test_draw_shadow_cache_cleared_on_size_change():
     h._SHADOW_CACHE.clear()
     h._SHADOW_SIZE = None
 
-    with patch("tienlen_gui.helpers.get_font", return_value=DummyFont()), patch(
-        "tienlen_gui.view.get_font", return_value=DummyFont()
+    with (
+        patch("tienlen_gui.helpers.get_font", return_value=DummyFont()),
+        patch("tienlen_gui.view.get_font", return_value=DummyFont()),
     ):
         with patch.object(
             tienlen_gui,
@@ -148,6 +151,7 @@ def test_draw_surface_shadow_uses_default_constants():
     with patch("pygame.Surface", return_value=shadow):
         tienlen_gui.draw_surface_shadow(target, img, rect)
     from tienlen_gui import helpers as h
+
     shadow.set_alpha.assert_called_once_with(h.SHADOW_ALPHA)
     expected = (h.SHADOW_BLUR * 2 + 1) ** 2
     assert target.blit.call_count == expected
@@ -202,8 +206,9 @@ def test_draw_glow_uses_cache(monkeypatch):
 
 def test_draw_players_uses_draw_shadow():
     view, _ = make_view()
-    with patch("tienlen_gui.helpers.get_font", return_value=DummyFont()), patch(
-        "tienlen_gui.view.get_font", return_value=DummyFont()
+    with (
+        patch("tienlen_gui.helpers.get_font", return_value=DummyFont()),
+        patch("tienlen_gui.view.get_font", return_value=DummyFont()),
     ):
         with patch.object(
             tienlen_gui,
@@ -274,9 +279,10 @@ def test_draw_players_highlights_active_zone():
     view.hand_sprites = pygame.sprite.LayeredUpdates()
     view.ai_sprites = [pygame.sprite.LayeredUpdates() for _ in range(3)]
     zone = pygame.Rect(0, 0, 10, 10)
-    with patch.object(view, "_player_zone_rect", return_value=zone), patch.object(
-        tienlen_gui.view, "draw_glow"
-    ) as glow:
+    with (
+        patch.object(view, "_player_zone_rect", return_value=zone),
+        patch.object(tienlen_gui.view, "draw_glow") as glow,
+    ):
         view.game.current_idx = 2
         view.draw_players()
     assert glow.call_count == 1
@@ -327,9 +333,11 @@ def test_animate_flip_moves_to_destination():
     view, clock = make_view()
     view.screen = MagicMock()
     sprite = DummyCardSprite()
-    with patch.object(
-        tienlen_gui, "get_card_back", return_value=pygame.Surface((1, 1))
-    ), patch("pygame.event.pump"), patch("pygame.display.update"):
+    with (
+        patch.object(tienlen_gui, "get_card_back", return_value=pygame.Surface((1, 1))),
+        patch("pygame.event.pump"),
+        patch("pygame.display.update"),
+    ):
         gen = view._animate_flip([sprite], (10, 5), duration=4 / 60)
         next(gen)
         steps = 0
@@ -350,9 +358,11 @@ def test_animate_glow_draws_glow():
     view, _ = make_view()
     view.screen = MagicMock()
     sprite = DummyCardSprite()
-    with patch.object(tienlen_gui.animations, "draw_glow") as glow, patch(
-        "pygame.event.pump"
-    ), patch("pygame.display.update"):
+    with (
+        patch.object(tienlen_gui.animations, "draw_glow") as glow,
+        patch("pygame.event.pump"),
+        patch("pygame.display.update"),
+    ):
         gen = view._animate_glow([sprite], (1, 2, 3), duration=2 / 60)
         next(gen)
         gen.send(1 / 60)
@@ -384,11 +394,13 @@ def test_highlight_turn_draws_at_player_position():
     view.screen = MagicMock()
     view.screen.get_size.return_value = (100, 100)
     overlay_surface = MagicMock()
-    with patch("pygame.Surface", return_value=overlay_surface) as surf_mock, patch(
-        "pygame.event.pump"
-    ), patch("pygame.display.update"), patch("pygame.draw.circle"), patch.object(
-        view, "_player_pos", return_value=(50, 100)
-    ) as pos:
+    with (
+        patch("pygame.Surface", return_value=overlay_surface) as surf_mock,
+        patch("pygame.event.pump"),
+        patch("pygame.display.update"),
+        patch("pygame.draw.circle"),
+        patch.object(view, "_player_pos", return_value=(50, 100)) as pos,
+    ):
         gen = view._highlight_turn(0, duration=2 / 60)
         next(gen)
         gen.send(1 / 60)
@@ -408,9 +420,12 @@ def test_animate_pass_text_draws_panel():
     view.screen = MagicMock()
     zone = pygame.Rect(0, 0, 10, 10)
     panel = pygame.Surface((2, 2))
-    with patch.object(view, "_player_zone_rect", return_value=zone) as rect_mock, patch.object(
-        view, "_hud_box", return_value=panel
-    ) as hud, patch("pygame.event.pump"), patch("pygame.display.update"):
+    with (
+        patch.object(view, "_player_zone_rect", return_value=zone) as rect_mock,
+        patch.object(view, "_hud_box", return_value=panel) as hud,
+        patch("pygame.event.pump"),
+        patch("pygame.display.update"),
+    ):
         gen = view._animate_pass_text(1, duration=2 / 60)
         next(gen)
         gen.send(1 / 60)
@@ -504,10 +519,7 @@ def test_animate_deal_moves_cards():
     view, _ = make_view()
     deck = view._pile_center()
     groups = [view.hand_sprites.sprites()] + [g.sprites() for g in view.ai_sprites]
-    dests = [
-        [tuple(map(int, getattr(sp, "pos", sp.rect.center))) for sp in grp]
-        for grp in groups
-    ]
+    dests = [[tuple(map(int, getattr(sp, "pos", sp.rect.center))) for sp in grp] for grp in groups]
     gen = view._animate_deal(duration=1 / 60, delay=0)
     next(gen)
     for grp in groups:

--- a/tests/test_gui_hud.py
+++ b/tests/test_gui_hud.py
@@ -1,15 +1,16 @@
-import os
 from unittest.mock import patch
-import pytest
+
 import pygame
-import tienlen_gui
+import pytest
+
 import tienlen
+import tienlen_gui
 from conftest import make_view
 
 pytest.importorskip("PIL")
 pytest.importorskip("pygame")
 
-os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+pytestmark = pytest.mark.gui
 
 
 def test_hud_panel_displays_count_and_last_move():
@@ -70,6 +71,7 @@ def test_hud_highlight_switches_on_turn_change():
         assert glow.call_count == 1
     pygame.quit()
 
+
 def test_hud_panel_shows_custom_ai_settings():
     view, _ = make_view()
     player = view.game.players[1]
@@ -79,6 +81,6 @@ def test_hud_panel_shows_custom_ai_settings():
     with patch.object(view, "_hud_box", return_value=pygame.Surface((1, 1))) as hud_box:
         hud._create_surface()
     lines = hud_box.call_args.args[0]
-    assert f"Difficulty: Hard" in lines
-    assert f"Personality: defensive" in lines
+    assert "Difficulty: Hard" in lines  # noqa: F541
+    assert "Personality: defensive" in lines  # noqa: F541
     pygame.quit()

--- a/tests/test_gui_input.py
+++ b/tests/test_gui_input.py
@@ -1,15 +1,16 @@
-import os
-from unittest.mock import patch, MagicMock
-import pytest
+from unittest.mock import MagicMock, patch
+
 import pygame
+import pytest
+
 import tienlen_gui
-from conftest import make_view, DummySprite, DummyCardSprite
+from conftest import DummyCardSprite, DummySprite, make_view
 
 pytest.importorskip("PIL")
 pytest.importorskip("pygame")
 
-# Use dummy video driver so no window is opened
-os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+pytestmark = pytest.mark.gui
 
 
 def test_handle_key_shortcuts():
@@ -72,9 +73,11 @@ def test_handle_mouse_selects_rightmost_sprite():
     view.selected = []
     view.state = tienlen_gui.GameState.PLAYING
     view.action_buttons = []
-    with patch.object(view, "update_play_button_state"), patch.object(
-        view, "_highlight_turn"
-    ), patch.object(view, "_animate_avatar_blink"):
+    with (
+        patch.object(view, "update_play_button_state"),
+        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_animate_avatar_blink"),
+    ):
         view.handle_mouse((5, 5))
     assert right.selected is True
     assert right in view.selected
@@ -114,9 +117,11 @@ def test_handle_mouse_calls_update_play_button_state():
     view.selected = []
     view.state = tienlen_gui.GameState.PLAYING
     view.action_buttons = []
-    with patch.object(view, "update_play_button_state") as upd, patch.object(
-        view, "_highlight_turn"
-    ), patch.object(view, "_animate_avatar_blink"):
+    with (
+        patch.object(view, "update_play_button_state") as upd,
+        patch.object(view, "_highlight_turn"),
+        patch.object(view, "_animate_avatar_blink"),
+    ):
         view.handle_mouse(sprite.rect.center)
         upd.assert_called()
 

--- a/tests/test_gui_snapshots.py
+++ b/tests/test_gui_snapshots.py
@@ -1,0 +1,25 @@
+import hashlib
+
+import pygame
+import pytest
+
+from conftest import make_view
+
+pytest.importorskip("pygame")
+
+pytestmark = pytest.mark.gui
+
+BASELINE_MAIN_MENU = "bc83cfecd606f577c01369720e3b64d9"
+
+
+def _hash_surface(surf: pygame.Surface) -> str:
+    return hashlib.md5(pygame.image.tobytes(surf, "RGB")).hexdigest()
+
+
+def test_main_menu_overlay_snapshot():
+    view, _ = make_view(200, 200)
+    view.show_menu()
+    surf = pygame.Surface((200, 200))
+    view.overlay.draw(surf)
+    assert _hash_surface(surf) == BASELINE_MAIN_MENU
+    pygame.quit()

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,14 +1,14 @@
-import os
 import time
 from unittest.mock import patch
-import pytest
+
 import pygame
+import pytest
+
 import tienlen_gui
 
 pytest.importorskip("pygame")
 
-# Use dummy video driver so no window is opened
-os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+pytestmark = pytest.mark.gui
 
 
 class DummyFont:
@@ -38,8 +38,9 @@ def make_view():
     clock = PerfClock()
     tienlen_gui.clear_font_cache()
     with patch("pygame.display.set_mode", return_value=pygame.Surface((1, 1))):
-        with patch("tienlen_gui.view.get_font", return_value=DummyFont()), patch(
-            "tienlen_gui.helpers.get_font", return_value=DummyFont()
+        with (
+            patch("tienlen_gui.view.get_font", return_value=DummyFont()),
+            patch("tienlen_gui.helpers.get_font", return_value=DummyFont()),
         ):
             with patch.object(tienlen_gui, "load_card_images"):
                 with patch("pygame.time.Clock", return_value=clock):
@@ -74,10 +75,13 @@ def test_custom_fps_limit_passed_to_clock():
     view, clock = make_view()
     view.fps_limit = 30
 
-    with patch(
-        "pygame.event.get",
-        return_value=[pygame.event.Event(pygame.QUIT, {})],
-    ), patch("pygame.quit"):
+    with (
+        patch(
+            "pygame.event.get",
+            return_value=[pygame.event.Event(pygame.QUIT, {})],
+        ),
+        patch("pygame.quit"),
+    ):
         view.run()
 
     assert clock.args[0] == 30

--- a/tests/test_player_pos.py
+++ b/tests/test_player_pos.py
@@ -1,13 +1,13 @@
-import os
 from unittest.mock import patch
-import pytest
+
 import pygame
+import pytest
+
 import tienlen_gui
 
 pytest.importorskip("pygame")
 
-# Use dummy video driver so no window is opened
-os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+pytestmark = pytest.mark.gui
 
 
 class DummyFont:
@@ -21,8 +21,9 @@ def make_view(width=200, height=200):
     pygame.display.init()
     tienlen_gui.clear_font_cache()
     with patch("pygame.display.set_mode", return_value=pygame.Surface((width, height))):
-        with patch("tienlen_gui.view.get_font", return_value=DummyFont()), patch(
-            "tienlen_gui.helpers.get_font", return_value=DummyFont()
+        with (
+            patch("tienlen_gui.view.get_font", return_value=DummyFont()),
+            patch("tienlen_gui.helpers.get_font", return_value=DummyFont()),
         ):
             with patch.object(tienlen_gui, "load_card_images"):
                 view = tienlen_gui.GameView(width, height)


### PR DESCRIPTION
## Summary
- setup Pygame in headless mode via a session fixture
- register the `gui` pytest mark
- mark GUI-related tests with `@pytest.mark.gui`
- add a snapshot test for the main menu overlay
- enable mypy checks

## Testing
- `flake8 --max-line-length=120 --extend-ignore=E203,W503 conftest.py tests/test_ai_rotation.py tests/test_event_loop.py tests/test_get_font.py tests/test_gui_animations.py tests/test_gui_hud.py tests/test_gui_input.py tests/test_gui_overlays.py tests/test_memory_usage.py tests/test_performance.py tests/test_player_pos.py tests/test_gui_snapshots.py`
- `mypy conftest.py tests/test_ai_rotation.py tests/test_event_loop.py tests/test_get_font.py tests/test_gui_animations.py tests/test_gui_hud.py tests/test_gui_input.py tests/test_gui_overlays.py tests/test_memory_usage.py tests/test_performance.py tests/test_player_pos.py tests/test_gui_snapshots.py`
- `pytest tests/test_gui_snapshots.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6879296fe278832689f40347e4f1b478