### PR TITLE
Add wheel entry points and packaging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,33 @@ python -m pdb -m tienlen_gui.view
 If the optional `pgdb` package is installed, it may be used in the same
 way to get a prettier interface.
 
+## Packaging & Distribution
+
+Build a wheel using the standard `build` module:
+
+```bash
+python -m build
+```
+
+All GUI assets are included under `tienlen_gui/assets` thanks to the
+``package-data`` setting in *pyproject.toml*. Inspect the wheel to verify:
+
+```bash
+unzip -l dist/tien_len-*.whl | grep assets | head
+```
+
+Install the wheel in a clean virtual environment and run both entry
+points:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install dist/tien_len-*.whl
+tien-len --help
+tien-len-gui --help
+```
+
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ dev = [
 ]
 
 
-[project.gui-scripts]
-tien-len = "tienlen_gui:main"
-
 [project.scripts]
-tien-len-cli = "tienlen:main"
+tien-len = "tienlen.cli:main"
+
+[project.gui-scripts]
+tien-len-gui = "tienlen_gui.app:main"
 
 [tool.setuptools]
 packages = {find = {where = ["src"]}}

--- a/src/tienlen/cli.py
+++ b/src/tienlen/cli.py
@@ -1,0 +1,12 @@
+"""Command line interface entry point for Tiến Lên."""
+
+from .game import main as _game_main
+
+
+def main() -> None:
+    """Run the game via the CLI."""
+    _game_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tienlen_gui/app.py
+++ b/src/tienlen_gui/app.py
@@ -1,0 +1,12 @@
+"""Entry point for launching the Pygame GUI."""
+
+from .view import GameView
+
+
+def main() -> None:
+    """Run the graphical version of the game."""
+    GameView().run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CLI and GUI entry points
- document how to build and validate the wheel
- configure entry points in pyproject

## Testing
- `pytest -q`
- `python -m build`
- `tien-len --help`
- `tien-len-gui & sleep 2; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68792e1ec2488326b1d91544bf6738a9