### PR TITLE
Fix deal animation update loop

### DIFF
--- a/src/tienlen_gui/animations.py
+++ b/src/tienlen_gui/animations.py
@@ -484,7 +484,7 @@ class AnimationMixin:
                 if start_delay > 0:
                     tl.wait(start_delay)
 
-                def start_move(sp=sp, dest=dest, group=group):
+                def start_move(sp=sp, dest=dest, group=group, mgr=mgr):
                     group.change_layer(sp, group.get_top_layer() + 1)
                     mgr.tween_position(dest, move_dur, 'smooth')
 
@@ -494,9 +494,11 @@ class AnimationMixin:
                 tl.then(start_move).wait(move_dur).then(reset_layer)
                 mgr.play(tl)
 
-        yield
+        dt = yield
         while any(m.active() for m in managers):
-            yield
+            for m in managers:
+                m.update(dt)
+            dt = yield
 
     def _animate_return(
         self,


### PR DESCRIPTION
## Summary
- handle `AnimationManager` updates inside the deal animation loop
- ensure each deal animation uses its own animation manager

## Testing
- `pytest tests/test_gui_animations.py::test_animate_deal_moves_cards -vv -s` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68793ccf6adc8326b371ca12feb1f8d3