### PR TITLE
docs: add architecture and AI strategy guides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,50 @@
+# Tiến Lên – Architecture Overview
+
+This document summarizes the current high-level architecture and proposed seams for future work.
+
+## Modules (high level)
+
+```text
++--------------------+        +--------------------+
+|  CLI (tienlen)     |        |  GUI (tienlen_gui) |
+|  - argparse / I/O  |        |  - Pygame view     |
+|  - game loop glue  |        |  - sprites/layout  |
++----------+---------+        +----------+---------+
+           |                             |
+           v                             v
+       +---+-----------------------------+---+
+       |           Game Engine               |
+       |  - State (players, hands, pile)     |
+       |  - Rules (validation, compare)      |
+       |  - Turn/round sequencing            |
+       +---+-----------------------------+---+
+           |                             |
+           v                             v
+      +----+----+                   +----+----+
+      |   AI    |                   |  Assets |
+      | - policy|                   |  images |
+      | - eval  |                   |  audio  |
+      +---------+                   +---------+
+```
+
+## Data flow
+1. **Input** (mouse/keyboard or CLI args) → controller logic maps events to **engine** actions.
+2. **Engine** mutates a single authoritative **GameState**.
+3. **Renderer** (GUI) observes state and redraws; **CLI** prints summaries.
+4. **AI** requests a view of legal moves from **Rules**, evaluates them, selects one.
+5. **Persistence**: options & profiles at `~/.tien_len/options.json`; saves at `~/.tien_len/saved_game.json` (add a `"schema": 1` field for migrations).
+
+## Extension points
+- **AI strategy**: separate *Evaluator* (scoring) from *Selector* (risk appetite via weighted biases).
+- **Layout**: keep **linear row + responsive spacing** now; add optional fan/arc later for large hands.
+- **Animations/SFX**: time-based animations (delta-ms), cache pre-rendered card surfaces (front/back, glow).
+
+## Performance tips
+- Call `convert()`/`convert_alpha()` on images at load.
+- Cache card surfaces (including glow variants) instead of rebuilding each frame.
+- Pre-render static text surfaces and reuse.
+
+## Testing boundaries
+- High-coverage unit tests for **Rules** and **Engine** (pure logic).
+- Golden tests for AI: fixed hands → expected *distribution* of move classes.
+- GUI smoke tests under headless Pygame (`SDL_VIDEODRIVER=dummy`); exclude from coverage.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,21 @@
+### What
+Docs/templates PR to make the project more contributor-friendly and pave the way for AI personality refactors.
+
+**Adds**
+- `ARCHITECTURE.md` with high-level diagram and data-flow.
+- `docs/AI_PERSONALITY_STRATEGY.md` describing the weighted-bias design (Evaluator vs Selector).
+- `docs/RELEASE_CHECKLIST.md` for tagging `v0.1.0` and shipping a Windows EXE.
+- Issue templates: bug, feature, rule clarification.
+- `pull_request_template.md`.
+
+**Does not change code paths** (safe to merge anytime).
+
+### Why
+- Lowers onboarding friction for contributors (and Future You).
+- Locks in the AI personality approach (weighted biases) without coupling to current code.
+- Preps the repo for screenshots/GIFs and a first tagged release.
+
+### Follow-ups (separate PRs)
+- Inject `weights` into the existing evaluator; split difficulty (search budget) from personality (bias).
+- Add `"schema": 1` to save files and a migration shim.
+- Add small UX touches: "thinking" pulse, last-move summary overlay, reduced-motion toggle.

--- a/docs/AI_PERSONALITY_STRATEGY.md
+++ b/docs/AI_PERSONALITY_STRATEGY.md
@@ -1,0 +1,60 @@
+# AI Personalities (Weighted Biases)
+
+Goal: keep **difficulty** and **personality** orthogonal.
+
+- **Difficulty** controls search budget (breadth/depth, lookahead toggle).
+- **Personality** applies *weights* to the evaluator's factors. It never hard-blocks a move; it nudges EV up/down.
+
+## Factors (example)
+- `finish_priority`: prefer lines that empty the hand sooner.
+- `bomb_risk`: penalize bombing early vs saving for pivotal cuts.
+- `lead_aggression`: value taking lead to sculpt endgame.
+- `defense_holdouts`: weight of keeping breakers (2s, bombs).
+- `sequence_value`: value of maintaining/creating straights/runs.
+- `opponent_pressure`: prefer plays that reduce opponents’ options (based on last lead).
+
+## Personalities (suggested defaults)
+
+| Personality | finish_priority | bomb_risk | lead_aggression | defense_holdouts | sequence_value | opponent_pressure |
+|-------------|-----------------|-----------|------------------|------------------|----------------|-------------------|
+| aggressive  | +0.30           | -0.15     | +0.25            | -0.10            | +0.10          | +0.20             |
+| defensive   | +0.15           | +0.20     | -0.10            | +0.25            | +0.10          | +0.05             |
+| balanced    | +0.20           | +0.05     | +0.05            | +0.10            | +0.10          | +0.10             |
+| random      | jitter(+/−0.2)  | jitter    | jitter           | jitter           | jitter         | jitter            |
+
+*Interpretation*: weights are additive biases on a normalized base score (e.g., 0..1). The evaluator combines base heuristics → `base_score`; the selector adds weighted biases → `final_score` and samples argmax with slight temperature for non-determinism.
+
+## JSON config sketch
+```json
+{
+  "ai": {
+    "difficulty": "Normal",
+    "lookahead": false,
+    "personality": "balanced",
+    "weights": {
+      "finish_priority": 0.20,
+      "bomb_risk": 0.05,
+      "lead_aggression": 0.05,
+      "defense_holdouts": 0.10,
+      "sequence_value": 0.10,
+      "opponent_pressure": 0.10
+    }
+  }
+}
+```
+
+## Minimal interface
+```python
+class Evaluator:
+    def score(self, state, move) -> float:
+        ...
+
+class Selector:
+    def choose(self, state, legal_moves, evaluator, weights) -> Move:
+        # compute base scores
+        # add weighted biases
+        # pick move (argmax with tiny temperature)
+        ...
+```
+
+Start by injecting a `weights` dict where your current evaluator aggregates heuristics. No functional change for defaults; personalities just tweak these weights.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,20 @@
+# Release Checklist
+
+Use this guide when tagging `v0.1.0` and shipping a Windows executable.
+
+## Prep
+- [ ] Run `pytest` and ensure all tests pass.
+- [ ] Update version strings (e.g. in `pyproject.toml`) and commit.
+- [ ] Refresh documentation and screenshots/GIFs as needed.
+
+## Tag
+- [ ] Create a git tag: `git tag v0.1.0`.
+- [ ] Push tags: `git push --tags`.
+
+## Build
+- [ ] Build the Windows EXE with PyInstaller: `bash build_exe.sh`.
+- [ ] Upload the executable to the GitHub release.
+
+## Final
+- [ ] Draft release notes and publish.
+- [ ] Announce the release.


### PR DESCRIPTION
## Summary
- outline high-level architecture with data flow and extension points
- document AI personality system using weighted biases
- add release checklist for tagging v0.1.0 and building Windows exe

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895fb4fdc1c8326885a612acfff4319