### PR TITLE
Improve CI and test configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,25 +2,57 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, master ]
   pull_request:
+    branches: [ "*" ]
 
 jobs:
-  build:
+  test:
+    name: tests (py${{ matrix.python-version }} / ubuntu)
     runs-on: ubuntu-latest
-    env:
-      SDL_VIDEODRIVER: dummy
-      SDL_AUDIODRIVER: dummy
+    timeout-minutes: 25
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
+    env:
+      # Hard-force headless Pygame
+      SDL_VIDEODRIVER: dummy
+      SDL_AUDIODRIVER: dummy
+      PYGAME_HIDE_SUPPORT_PROMPT: "1"
+      PYTHONFAULTHANDLER: "1"
+      # Make pytest output consistent and informative by default
+      PYTEST_ADDOPTS: "-q --maxfail=1 --durations=25 --color=yes --timeout=120 --timeout-method=thread"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies and run tests
+          cache: "pip"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install package (editable) + test deps
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .[test]
-          pytest -vv
+          python -m pip install -e ".[test]"
+
+      - name: Show environment
+        run: |
+          python -V
+          python -c "import sys,pygame; print('pygame', pygame.version.ver); print('SDL_VIDEODRIVER', __import__('os').environ.get('SDL_VIDEODRIVER'))"
+
+      # Step-level guard even if pytest-timeout fails to interrupt
+      - name: Run tests
+        run: |
+          timeout 20m python -m pytest
+        shell: bash
+
+      - name: Upload coverage (artifact)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.python-version }}
+          path: ./.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tien-len"
 version = "0.1.0"
 description = "Tiến Lên card game with CLI and Pygame GUI"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "pillow>=10,<12",
     "pygame-ce>=2.5,<3",
@@ -17,6 +17,8 @@ dependencies = [
 test = [
     "pytest>=8,<9",
     "coverage>=7,<8",
+    "pytest-timeout>=2.3",
+    "pytest-xdist>=3",  # optional, disable if Pygame isn't process-safe
 ]
 dev = [
     "pre-commit>=3,<4",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,9 @@
 [pytest]
+addopts = -q --maxfail=1 --durations=25 --color=yes --timeout=120 --timeout-method=thread
+# Mark GUI tests so they can be filtered if needed later (e.g., -m "not gui")
 markers =
-    gui: tests that require pygame display
+    gui: tests that touch Pygame surfaces/windows
+    slow: longer-running tests
+
+# If a test hangs, faulthandler dumps stack traces on SIGALRM (pytest-timeout uses this).
+faulthandler_timeout = 120


### PR DESCRIPTION
## Summary
- Add comprehensive GitHub Actions workflow running tests on Python 3.11-3.12 with headless Pygame and coverage artifact upload
- Expand pytest settings with default timeouts, markers, and faulthandler configuration
- Require Python 3.11 and include pytest-timeout and pytest-xdist in test extras

## Testing
- `pre-commit run --files .github/workflows/ci.yml pytest.ini pyproject.toml`
- `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 python -m pytest` *(fails: Timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6895ff29fd748326add71fe353477e63