### PR TITLE
Add coverage reporting and Codecov upload in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,28 @@
 [run]
 branch = True
+source =
+    tienlen
+    tienlen_gui
 omit =
-    tienlen_gui/*.py
+    */__main__.py
+    */__init__.py
+    */_version.py
+    */build/* 
+    */dist/*
+    */.venv/*
+    */venv/*
+    */site-packages/*
+    tests/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:
+    if __name__ == .__main__.: 
+    raise NotImplementedError
+    @overload
+show_missing = True
+precision = 1
+
+[xml]
+output = coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,38 @@ jobs:
           python -c "import sys,pygame; print('pygame', pygame.version.ver); print('SDL_VIDEODRIVER', __import__('os').environ.get('SDL_VIDEODRIVER'))"
 
       # Step-level guard even if pytest-timeout fails to interrupt
-      - name: Run tests
+      - name: Run tests under coverage
         run: |
-          timeout 20m python -m pytest
+          timeout 20m coverage run -m pytest
         shell: bash
 
-      - name: Upload coverage (artifact)
+      - name: Generate coverage XML & text reports
+        run: |
+          coverage xml
+          coverage report -m || true
+
+      - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.python-version }}
-          path: ./.coverage
+          path: |
+            ./.coverage
+            ./coverage.xml
+
+      - name: Codecov upload
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: unittests,py${{ matrix.python-version }}
+          name: tien-len-${{ matrix.python-version }}
+          verbose: true
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }} # not needed for public repos
+
+      - name: Append coverage summary to job
+        if: always()
+        run: |
+          echo "### Coverage (py${{ matrix.python-version }})" >> $GITHUB_STEP_SUMMARY
+          coverage report -m >> $GITHUB_STEP_SUMMARY || true


### PR DESCRIPTION
## Summary
- run pytest under coverage and publish XML/summary
- upload coverage data and send report to Codecov
- configure coverage to focus on project sources

## Testing
- `python -m coverage run -m pytest` *(timed out at tests/test_gui_animations.py::test_animate_deal_moves_cards)*
- `python -m coverage run -m pytest -m "not gui"` *(ModuleNotFoundError: No module named 'sound')*
- `python -m coverage xml`
- `python -m coverage report -m || true`


------
https://chatgpt.com/codex/tasks/task_e_68960f49c4f083268d395c169156f1a1