### PR TITLE
Add guards for Timeline callable steps

### DIFF
--- a/src/tienlen_gui/animations.py
+++ b/src/tienlen_gui/animations.py
@@ -500,6 +500,13 @@ class AnimationMixin:
                 m.update(dt)
             dt = yield
 
+        for (group, grp), dest_grp in zip(groups, destinations):
+            for sp, dest in zip(grp, dest_grp):
+                if hasattr(sp, "pos"):
+                    sp.pos.update(dest)
+                else:
+                    sp.rect.center = (int(dest[0]), int(dest[1]))
+
     def _animate_return(
         self,
         player_idx: int,

--- a/src/tienlen_gui/tween.py
+++ b/src/tienlen_gui/tween.py
@@ -75,7 +75,12 @@ class Timeline:
 
     def update(self, dt: float) -> None:
         """Advance the timeline by ``dt`` seconds."""
+        MAX_STEPS = 1000
+        steps = 0
         while dt > 0 or (dt == 0 and self._current is None and self._steps):
+            if steps >= MAX_STEPS:
+                break
+            steps += 1
             if self._current is None:
                 if not self._steps:
                     break
@@ -92,6 +97,7 @@ class Timeline:
                     self._current = (step, None)
                 else:
                     step()
+                    dt = 0
                     continue
             consumed = self._advance(dt)
             if isinstance(self._current, tuple) and self._current[0].finished:


### PR DESCRIPTION
## Summary
- prevent Timeline.update from executing unbounded callable chains by capping iterations and zeroing remaining dt
- ensure dealing animation resets sprites to their intended destinations after playback

## Testing
- `pytest tests/test_gui_animations.py::test_animate_deal_moves_cards -q`


------
https://chatgpt.com/codex/tasks/task_e_68962536c34883268e1cacb5b60ac419