### PR TITLE
Use fan layout for player hand

### DIFF
--- a/src/tienlen_gui/view.py
+++ b/src/tienlen_gui/view.py
@@ -49,8 +49,6 @@ from .overlay_manager import OverlayMixin
 
 logger = logging.getLogger(__name__)
 
-# Number of cards required to switch to a fanned layout for the human player
-FAN_THRESHOLD = 16
 
 
 class GameView(AnimationMixin, HUDMixin, OverlayMixin):
@@ -1046,26 +1044,15 @@ class GameView(AnimationMixin, HUDMixin, OverlayMixin):
 
         # --- Human player at the bottom ---------------------------------
         player = self.game.players[0]
-        if len(player.hand) > FAN_THRESHOLD:
-            layout = calc_fan_layout(screen_w, card_w, len(player.hand), self.hand_y, card_w)
-            for i, card in enumerate(player.hand):
-                x, y, angle = layout[i]
-                sprite = CardSprite(card, (x, y - card_h // 2), card_w, rotation=angle)
-                sprite.pos.y = y
-                sprite.update()
-                sprite._layer = i
-                self._manager_for(sprite)
-                self.hand_sprites.add(sprite, layer=i)
-        else:
-            start_x, spacing = calc_hand_layout(screen_w, card_w, len(player.hand))
-            y = self.hand_y - card_h // 2
-            for i, card in enumerate(player.hand):
-                sprite = CardSprite(card, (start_x + i * spacing, y), card_w)
-                sprite.pos.y = self.hand_y
-                sprite.update()
-                sprite._layer = i
-                self._manager_for(sprite)
-                self.hand_sprites.add(sprite, layer=i)
+        layout = calc_fan_layout(screen_w, card_w, len(player.hand), self.hand_y, card_w)
+        for i, card in enumerate(player.hand):
+            x, y, angle = layout[i]
+            sprite = CardSprite(card, (x, y - card_h // 2), card_w, rotation=angle)
+            sprite.pos.y = y
+            sprite.update()
+            sprite._layer = i
+            self._manager_for(sprite)
+            self.hand_sprites.add(sprite, layer=i)
 
         margin_v = bottom_margin(card_w)
 

--- a/tests/test_player_arc_layout.py
+++ b/tests/test_player_arc_layout.py
@@ -1,0 +1,23 @@
+import pygame
+import pytest
+
+import tienlen_gui
+from conftest import make_view
+
+pytest.importorskip("pygame")
+pytestmark = pytest.mark.gui
+
+
+def test_human_hand_uses_fan_layout_for_small_counts():
+    view, _ = make_view(300, 200)
+    # shrink the human player's hand to a few cards
+    view.game.players[0].hand = view.game.players[0].hand[:3]
+    view.update_hand_sprites()
+    sprites = view.hand_sprites.sprites()
+    ys = [s.rect.centery for s in sprites]
+    base_y = view._player_pos(0)[1]
+    # outer cards should align with base_y while center card is above
+    assert ys[0] == base_y
+    assert ys[-1] == base_y
+    assert min(ys) < base_y
+    pygame.quit()


### PR DESCRIPTION
## Summary
- Replace straight human hand with fan-style arc layout while keeping AI hands linear
- Provide placeholder card surfaces when art is missing and add regression test for fanned layout

## Testing
- `pytest -q` *(fails: Timeout in tests/test_gui_animations.py::test_animate_deal_moves_cards)*
- `pytest tests/test_player_arc_layout.py -q`
- `PYTHONPATH=src SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy timeout -s TERM 3 python -m tienlen_gui.app`

------
https://chatgpt.com/codex/tasks/task_e_68c499a32f9883268e28cb7f623861c9