### PR TITLE
Improve test setup and sound initialization

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 pytest>=8,<9
+pytest-timeout>=2.3
 coverage>=7,<8
 pre-commit>=3,<4
 black>=24,<25

--- a/src/tienlen/game.py
+++ b/src/tienlen/game.py
@@ -157,6 +157,16 @@ class Player:
         self.ai_level: Optional[str] = None
         self.ai_personality: Optional[str] = None
 
+    @classmethod
+    def from_dict(cls, data: dict) -> "Player":
+        """Build a player with hand and AI metadata restored."""
+
+        player = cls(data["name"], data.get("is_human", False))
+        player.hand = [Card.from_dict(c) for c in data.get("hand", [])]
+        player.ai_level = data.get("ai_level")
+        player.ai_personality = data.get("ai_personality")
+        return player
+
     def sort_hand(self, mode: str = "rank", flip_suit_rank: bool = False) -> None:
         """Sort the player's hand.
 
@@ -853,13 +863,7 @@ class Game:
     def from_dict(self, data: dict) -> None:
         """Restore game state from ``data`` (a dictionary)."""
 
-        self.players = [
-            Player(d["name"], d.get("is_human", False)) for d in data["players"]
-        ]
-        for p, dct in zip(self.players, data["players"]):
-            p.hand = [Card.from_dict(c) for c in dct.get("hand", [])]
-            p.ai_level = dct.get("ai_level")
-            p.ai_personality = dct.get("ai_personality")
+        self.players = [Player.from_dict(d) for d in data["players"]]
         self.pile = []
         for item in data.get("pile", []):
             idx = item.get("player")

--- a/src/tienlen/sound.py
+++ b/src/tienlen/sound.py
@@ -1,24 +1,52 @@
 """Simple sound effect utilities using pygame's mixer."""
 from __future__ import annotations
 
+import os
+import warnings
 from pathlib import Path
 from typing import Union
-import warnings
-import os
 
-try:
-    import pygame
-    if os.environ.get('SDL_AUDIODRIVER') != 'dummy':
-        pygame.mixer.init()
-        _ENABLED = True
-    else:
-        _ENABLED = False
-except Exception:  # pragma: no cover - if mixer init fails
-    pygame = None
-    _ENABLED = False
+import pygame
+
+_MIXER_CHECKED = False
+_MIXER_AVAILABLE = False
+_ENABLED = True
 
 _SOUNDS: dict[str, "pygame.mixer.Sound"] = {}
 _VOLUME = 1.0
+
+
+def _init_mixer() -> bool:
+    """Initialise the Pygame mixer lazily.
+
+    Returns ``True`` if the mixer is available and initialised.  The
+    initialisation is attempted at most once to avoid repeated log spam in
+    headless environments.
+    """
+
+    global _MIXER_CHECKED, _MIXER_AVAILABLE
+
+    if _MIXER_CHECKED:
+        return _MIXER_AVAILABLE
+
+    _MIXER_CHECKED = True
+    if os.environ.get("SDL_AUDIODRIVER") == "dummy":
+        _MIXER_AVAILABLE = False
+        return False
+
+    try:  # pragma: no cover - mixer init is environment-dependent
+        pygame.mixer.init()
+        _MIXER_AVAILABLE = True
+    except Exception:
+        _MIXER_AVAILABLE = False
+
+    return _MIXER_AVAILABLE
+
+
+def _ready() -> bool:
+    """Return ``True`` when sounds can be played."""
+
+    return _ENABLED and _init_mixer()
 
 
 def load(name: str, path: Union[str, Path]) -> bool:
@@ -27,7 +55,7 @@ def load(name: str, path: Union[str, Path]) -> bool:
     Returns ``True`` on success.  Loading does nothing if the mixer is
     disabled or the file does not exist.
     """
-    if not _ENABLED:
+    if not _ready():
         return False
     p = Path(path)
     if not p.is_file():
@@ -44,7 +72,7 @@ def load(name: str, path: Union[str, Path]) -> bool:
 
 def play(name: str) -> None:
     """Play a loaded sound effect identified by ``name``."""
-    if not _ENABLED:
+    if not _ready():
         return
     snd = _SOUNDS.get(name)
     if snd is None:
@@ -59,7 +87,7 @@ def set_volume(vol: float) -> None:
     """Set volume for all loaded sound effects."""
     global _VOLUME
     _VOLUME = max(0.0, min(1.0, vol))
-    if not _ENABLED:
+    if not _ready():
         return
     for snd in _SOUNDS.values():
         try:
@@ -72,3 +100,5 @@ def set_enabled(flag: bool) -> None:
     """Enable or disable all sound effects."""
     global _ENABLED
     _ENABLED = bool(flag)
+    if _ENABLED:
+        _init_mixer()


### PR DESCRIPTION
## Summary
- add pytest-timeout to the development requirements so pytest.ini options are satisfied out of the box
- lazily initialize the Pygame mixer and skip setup when a dummy audio driver is requested
- restore player AI metadata through a Player.from_dict helper when rebuilding game state

## Testing
- SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python -m pytest -q *(hangs near completion; interrupted with KeyboardInterrupt)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f62951858832693cf4856a2152b2e)